### PR TITLE
Fix `skipStories` format in the documentation

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -17,7 +17,7 @@ Example `package.json`:
         "height": 768
       },
       "chrome.iphone7": {
-        "skip-stories": "loading|MyFailingComponent",
+        "skipStories": "loading|MyFailingComponent",
         "target": "chrome.app",
         "preset": "iPhone 7"
       },


### PR DESCRIPTION
In the example the spelling is `skip-stories` (kebab-case) but the format is `skipStories` (camel-case).