### PR TITLE
ci: skip seccomp on ci

### DIFF
--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -50,7 +50,8 @@ function createChromeDockerTarget({
   const storybookUrl = baseUrl;
   const dockerPath = 'docker';
   const runArgs = ['run', '--rm', '-d', '-P'];
-  if (os.platform() === 'darwin') {
+
+  if (!process.env.CI) {
     runArgs.push(`--security-opt=seccomp=${__dirname}/docker-seccomp.json`);
   }
 


### PR DESCRIPTION
closes #13 

With this change seccomp files are skipped from CI, but in your local environment seccomp will be used.