### PR TITLE
Replace chrome-headless image by a tagged one

### DIFF
--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -79,7 +79,7 @@ function createChromeDockerTarget({
       .concat([
         '-p',
         `${port}:${port}`,
-        'armbues/chrome-headless',
+        'yukinying/chrome-headless-browser:63.0.3223.8',
         '--disable-datasaver-prompt',
         '--no-first-run',
         '--disable-extensions',


### PR DESCRIPTION
This PR replaces `armbues/chrome-headless` by `yukinying/chrome-headless:63.0.3209.2`.

The former was having some issues in Docker while starting:

```
Failed to move to new namespace: PID namespaces supported, Network namespace supported, but failed: errno = Operation not permitted
```

Also, the new container is tagged, so a new push will not break new builds.

The only thing I couldn't figure is how to do automatic height adjustment.