### PR TITLE
React native error handling

### DIFF
--- a/examples/react-native/storybook/stories/ErrorThrowingComponent/index.js
+++ b/examples/react-native/storybook/stories/ErrorThrowingComponent/index.js
@@ -1,0 +1,3 @@
+export default ErrorThrowingComponent = () => {
+  throw new Error('This error should be caught by loki');
+};

--- a/examples/react-native/storybook/stories/index.js
+++ b/examples/react-native/storybook/stories/index.js
@@ -10,6 +10,7 @@ import { linkTo } from '@storybook/addon-links';
 import Button from './Button';
 import CenterView from './CenterView';
 import Welcome from './Welcome';
+import ErrorThrowingComponent from './ErrorThrowingComponent';
 
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
 
@@ -25,3 +26,10 @@ storiesOf('Button', module)
       <Text>😀 😎 👍 💯</Text>
     </Button>
   );
+
+storiesOf('Error Handling', module)
+  .add('with ErrorThrowingComponent', () => <ErrorThrowingComponent />)
+  .add('with console.warn', () => {
+    console.warn('This warning should not show up in the screenshot');
+    return <Text>This story emits a console.warn</Text>;
+  });

--- a/src/errors.js
+++ b/src/errors.js
@@ -1,4 +1,5 @@
 const util = require('util');
+const path = require('path');
 
 function ReferenceImageError(message, kind, story) {
   Error.captureStackTrace(this, this.constructor);
@@ -28,14 +29,30 @@ function ServerError(message, instructions) {
   this.instructions = instructions;
 }
 
+function formatStackTraceLine({ file, methodName, lineNumber, column }) {
+  return `at ${methodName} (${path.relative(
+    '.',
+    file
+  )}:${lineNumber}:${column})`;
+}
+
+function NativeError(message, stack) {
+  this.name = this.constructor.name;
+  this.message = message;
+  this.rawStack = stack;
+  this.stack = stack && stack.map(formatStackTraceLine).join('\n');
+}
+
 util.inherits(ReferenceImageError, Error);
 util.inherits(TimeoutError, Error);
 util.inherits(MissingDependencyError, Error);
 util.inherits(ServerError, Error);
+util.inherits(NativeError, Error);
 
 module.exports = {
   ReferenceImageError,
   TimeoutError,
   MissingDependencyError,
   ServerError,
+  NativeError,
 };


### PR DESCRIPTION
Replaces default React Native crash handler and injects Loki instead to output errors thrown by the story to the terminal instead and automatically recover from the crash by reloading the app. 

As requested by @xaviervia
