### PR TITLE
Improve native image handling

### DIFF
--- a/examples/react-native/ios/Loki/Info.plist
+++ b/examples/react-native/ios/Loki/Info.plist
@@ -45,6 +45,13 @@
 	<dict>
 		<key>NSExceptionDomains</key>
 		<dict>
+			<key>deelay.me</key>
+			<dict>
+				<key>NSIncludesSubdomains</key>
+				<true/>
+				<key>NSTemporaryThirdPartyExceptionAllowsInsecureHTTPLoads</key>
+				<true/>
+			</dict>
 			<key>localhost</key>
 			<dict>
 				<key>NSExceptionAllowsInsecureHTTPLoads</key>

--- a/examples/react-native/storybook/stories/ErrorThrowingComponent/index.js
+++ b/examples/react-native/storybook/stories/ErrorThrowingComponent/index.js
@@ -1,3 +1,5 @@
-export default ErrorThrowingComponent = () => {
+const ErrorThrowingComponent = () => {
   throw new Error('This error should be caught by loki');
 };
+
+export default ErrorThrowingComponent;

--- a/examples/react-native/storybook/stories/Logo/index.js
+++ b/examples/react-native/storybook/stories/Logo/index.js
@@ -1,0 +1,26 @@
+import React from 'react';
+import PropTypes from 'prop-types';
+import { Image } from 'react-native';
+
+const DELAY_URL_PREFIX = 'http://www.deelay.me';
+
+const Logo = ({ delay, logoUrl }) => (
+  <Image
+    style={{ width: 75, height: 75 }}
+    source={{
+      uri: delay ? `${DELAY_URL_PREFIX}/${delay}/${logoUrl}` : logoUrl,
+    }}
+  />
+);
+
+Logo.propTypes = {
+  delay: PropTypes.number,
+  logoUrl: PropTypes.string,
+};
+
+Logo.defaultProps = {
+  delay: 0,
+  logoUrl: 'https://loki.js.org/favicon.png',
+};
+
+export default Logo;

--- a/examples/react-native/storybook/stories/index.js
+++ b/examples/react-native/storybook/stories/index.js
@@ -10,6 +10,7 @@ import { linkTo } from '@storybook/addon-links';
 import Button from './Button';
 import CenterView from './CenterView';
 import Welcome from './Welcome';
+import Logo from './Logo';
 import ErrorThrowingComponent from './ErrorThrowingComponent';
 
 storiesOf('Welcome', module).add('to Storybook', () => <Welcome showApp={linkTo('Button')} />);
@@ -26,6 +27,10 @@ storiesOf('Button', module)
       <Text>😀 😎 👍 💯</Text>
     </Button>
   );
+
+storiesOf('Logo', module)
+  .add('without delay', () => <Logo />)
+  .add('with 15s delay', () => <Logo delay={15000} />);
 
 storiesOf('Error Handling', module)
   .add('with ErrorThrowingComponent', () => <ErrorThrowingComponent />)

--- a/src/errors.js
+++ b/src/errors.js
@@ -36,11 +36,12 @@ function formatStackTraceLine({ file, methodName, lineNumber, column }) {
   )}:${lineNumber}:${column})`;
 }
 
-function NativeError(message, stack) {
+function NativeError(message, stack, isFatal = true) {
   this.name = this.constructor.name;
   this.message = message;
   this.rawStack = stack;
   this.stack = stack && stack.map(formatStackTraceLine).join('\n');
+  this.isFatal = isFatal;
 }
 
 util.inherits(ReferenceImageError, Error);

--- a/src/targets/native/configure-storybook.js
+++ b/src/targets/native/configure-storybook.js
@@ -117,6 +117,7 @@ async function configureStorybook() {
       if (isFatal) {
         emit('error', {
           error: await getPrettyError(error),
+          isFatal,
         });
         restore();
         setTimeout(() => {
@@ -140,10 +141,18 @@ async function configureStorybook() {
     emit('didRestore');
   });
 
-  channel.on('setCurrentStory', () => {
-    awaitImagesLoaded().finally(count => {
+  channel.on('setCurrentStory', async () => {
+    try {
+      const count = await awaitImagesLoaded();
       emit('imagesLoaded', { count });
-    });
+    } catch (error) {
+      emit('error', {
+        error: {
+          message: error.message,
+        },
+        isFatal: false,
+      });
+    }
     resetLoadingImages();
   });
 }

--- a/src/targets/native/create-message-queue.js
+++ b/src/targets/native/create-message-queue.js
@@ -17,8 +17,8 @@ const createMessageQueue = nativeErrorType => {
         (!item.condition || item.condition(...args))
       ) {
         if (isError) {
-          const error = args[0].error;
-          item.reject(new NativeError(error.message, error.stack));
+          const { error, isFatal } = args[0];
+          item.reject(new NativeError(error.message, error.stack, isFatal));
         } else {
           item.resolve(args[0]);
         }

--- a/src/targets/native/create-websocket-target.js
+++ b/src/targets/native/create-websocket-target.js
@@ -129,7 +129,7 @@ function createWebsocketTarget(socketUri, platform, saveScreenshotToFile) {
       debug('imagesLoaded', data);
     } catch (error) {
       if (error instanceof NativeError) {
-        lastStoryCrashed = true;
+        lastStoryCrashed = error.isFatal;
       }
       throw error;
     }

--- a/src/targets/native/ready-state-emitting-image.js
+++ b/src/targets/native/ready-state-emitting-image.js
@@ -10,28 +10,42 @@ class ReadyStateEmittingImage extends React.Component {
   constructor(props) {
     super(props);
 
-    let resolver = null;
     if (props.source) {
       registerImageLoading(
         new Promise(resolve => {
-          resolver = resolve;
-        })
+          this.resolve = resolve;
+        }),
+        props.source
       );
     }
-
-    this.handleLoadEnd = e => {
-      if (resolver) {
-        resolver();
-        resolver = null;
-      }
-      if (this.props.onLoadEnd) {
-        this.props.onLoadEnd(e);
-      }
-    };
   }
 
+  setNativeProps = (...args) => {
+    this.ref.setNativeProps(...args);
+  };
+
+  handleRef = ref => {
+    this.ref = ref;
+  };
+
+  handleLoadEnd = e => {
+    if (this.resolve) {
+      this.resolve();
+      this.resolve = null;
+    }
+    if (this.props.onLoadEnd) {
+      this.props.onLoadEnd(e);
+    }
+  };
+
   render() {
-    return <Image {...this.props} onLoadEnd={this.handleLoadEnd} />;
+    return (
+      <Image
+        {...this.props}
+        ref={this.handleRef}
+        onLoadEnd={this.handleLoadEnd}
+      />
+    );
   }
 }
 

--- a/src/targets/native/ready-state-manager.js
+++ b/src/targets/native/ready-state-manager.js
@@ -1,23 +1,36 @@
 let loadingImages = [];
 
-export const registerImageLoading = promise => {
-  loadingImages.push(promise);
+export const registerImageLoading = (promise, source) => {
+  const image = { promise, source, loaded: false };
+  promise.then(() => {
+    image.loaded = true;
+  });
+  loadingImages.push(image);
 };
 
 export const resetLoadingImages = () => {
   loadingImages = [];
 };
 
-export const awaitImagesLoaded = (timeout = 5000) => {
+export const awaitImagesLoaded = (timeout = 10000) => {
   let cancel;
   const promise = new Promise((resolve, reject) => {
-    const timer = setTimeout(reject, timeout);
+    const timer = setTimeout(() => {
+      const failedURLs = loadingImages
+        .filter(i => !i.loaded)
+        .map(i => i.source && i.source.uri);
+      const noun = failedURLs.length === 1 ? 'image' : 'images';
+      const errorMessage = `${failedURLs.length} ${noun} failed to load within ${timeout}ms; ${failedURLs.join(
+        ', '
+      )}`;
+      reject(new Error(errorMessage));
+    }, timeout);
     let canceled = false;
     cancel = () => {
       clearTimeout(timer);
       canceled = true;
     };
-    Promise.all(loadingImages).then(result => {
+    Promise.all(loadingImages.map(i => i.promise)).then(result => {
       if (!canceled) {
         clearTimeout(timer);
         // Resolve on next frame to avoid some race conditions


### PR DESCRIPTION
* When an image fails to load on React Native, instead of taking a screenshot and get an obvious diff, fail the story fast and detail what went wrong in the output. 
* Add `setNativeProps` to `ReadyStateEmittingImage` to fix crash when it's wrapped with a `TouchableOpacity`.
* Bump image load timeout to 10s.