### PR TITLE
Use tolerance when determining a match

### DIFF
--- a/src/diffing/looks-same.js
+++ b/src/diffing/looks-same.js
@@ -18,7 +18,7 @@ function getImageDiff(path1, path2, diffPath, tolerance) {
       return reject(new Error('Current image is empty'));
     }
 
-    return looksSame(reference, current, (err, isSame) => {
+    return looksSame(reference, current, { tolerance }, (err, isSame) => {
       if (err) {
         reject(err);
       } else if (isSame) {


### PR DESCRIPTION
Changing the `--chromeTolerance` was having an effect on the diff images, but not changing whether tests would pass or fail. This PR passes tolerance in as an option so that it will be used to determine matching.