### PR TITLE
Wait before capturing option

### DIFF
--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -186,7 +186,8 @@ function createChromeTarget(
     }
 
     const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
-    const waited = (configuration.waitBeforeCapture || []).find(x => new RegExp(x.story).test(story));
+    const waited = (configuration.waitBeforeCapture || [])
+        .find(x => new RegExp(x.kind).test(kind) && new RegExp(x.story).test(story));
     if (waited) {
         await sleep(waited.millSec);
     }

--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -186,9 +186,10 @@ function createChromeTarget(
     }
 
     const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
-    const waited = (configuration.waitBeforeCapture || []).find(
-      x => new RegExp(x.kind).test(kind) && new RegExp(x.story).test(story)
-    );
+    const waited = (configuration.waitBeforeCapture || [])
+      .find(
+        x => new RegExp(x.kind).test(kind) && new RegExp(x.story).test(story)
+      );
     if (waited) {
       await sleep(waited.millSec);
     }

--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -184,6 +184,13 @@ function createChromeTarget(
         throw err;
       }
     }
+
+    const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
+    const waited = (configuration.waitBeforeCapture || []).find(x => new RegExp(x.story).test(story));
+    if (waited) {
+        await sleep(waited.millSec);
+    }
+
     const screenshot = await tab.captureScreenshot(selector);
     await fs.outputFile(outputPath, screenshot);
     await tab.close();

--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -186,10 +186,11 @@ function createChromeTarget(
     }
 
     const sleep = msec => new Promise(resolve => setTimeout(resolve, msec));
-    const waited = (configuration.waitBeforeCapture || [])
-        .find(x => new RegExp(x.kind).test(kind) && new RegExp(x.story).test(story));
+    const waited = (configuration.waitBeforeCapture || []).find(
+      x => new RegExp(x.kind).test(kind) && new RegExp(x.story).test(story)
+    );
     if (waited) {
-        await sleep(waited.millSec);
+      await sleep(waited.millSec);
     }
 
     const screenshot = await tab.captureScreenshot(selector);


### PR DESCRIPTION
To avoid Issue #32, I suggest a feature as following.

---

`package.json`

```
  "loki": {
    "configurations": {
      "chrome.laptop": {
        "target": "chrome.docker",
        "waitBeforeCapture": [
          {
            "kind": "^DailyCard$",
            "story": "^Summary$",
            "millSec": 10000
          }
        ],
        .
        .
        "fitWindow": false
      }
    }
  }
```

Above means waiting 10secs before capturing if kind is `DailyCard` and story is `Summary`.

```
loki test v0.7.0
 ❯ Chrome (docker)
   ✔ Start
   ✔ Fetch list of stories
   ❯ Test chrome.laptop
     ❯ DailyCard
       ✔ Summary   <==== like this
```

![2017-11-09_22h43_10](https://user-images.githubusercontent.com/9500018/32608434-ae38d1e4-c59f-11e7-9a16-d4581259fbe7.gif)


Best regards.