### PR TITLE
Run sandboxed storybook bundle in sub process

### DIFF
--- a/src/targets/chrome/fetch-storybook-worker.js
+++ b/src/targets/chrome/fetch-storybook-worker.js
@@ -1,0 +1,77 @@
+const vm = require('vm');
+const fetchUrl = require('./fetch-url');
+const debug = require('debug')('loki:chrome:fetchStorybook');
+const getBrowserGlobals = require('./get-browser-globals');
+const { ServerError } = require('../../errors');
+
+async function createStorybookSandbox(baseUrl) {
+  debug(`Fetching iframe HTML and preview bundle JS from ${baseUrl}`);
+  const html = await fetchUrl(`${baseUrl}/iframe.html`);
+  const browser = getBrowserGlobals(html);
+  const scripts = browser.document.querySelectorAll('script[src]');
+  const previewSrc = Array.from(scripts)
+    .map(node => node.attributes.src.nodeValue)
+    .filter(src => src.match(/preview\.([a-f0-9]+\.)?bundle\.js/) !== -1)[0];
+
+  if (!previewSrc) {
+    throw new Error('Unable to locate preview bundle');
+  }
+
+  const bundle = await fetchUrl(`${baseUrl}/${previewSrc}`);
+
+  debug('Creating js sandbox');
+  const sandbox = vm.createContext(browser);
+
+  debug('Executing storybook preview bundle');
+  vm.runInNewContext(bundle, sandbox);
+
+  return sandbox;
+}
+
+async function fetchStorybook(baseUrl = 'http://localhost:6006') {
+  let sandbox;
+  try {
+    sandbox = await createStorybookSandbox(baseUrl);
+  } catch (err) {
+    if (err.message && err.message.indexOf('ECONNREFUSED') !== -1) {
+      throw new ServerError(
+        'Failed fetching stories because the server is down',
+        `Try starting it with "yarn storybook" or pass the --port or --host arguments if it's not running at ${baseUrl}`
+      );
+    }
+    throw err;
+  }
+
+  const getStorybook = sandbox.window.loki && sandbox.window.loki.getStorybook;
+  if (!getStorybook) {
+    throw new Error(
+      "Loki addon not registered. Add `import 'loki/configure-react'` to your config.js file."
+    );
+  }
+
+  return getStorybook().map(component => ({
+    kind: component.kind,
+    stories: component.stories.map(story => story.name),
+  }));
+}
+
+process.on('message', async baseUrl => {
+  try {
+    const storybook = await fetchStorybook(baseUrl);
+    process.send(JSON.stringify({ storybook }));
+  } catch (error) {
+    process.send(
+      JSON.stringify({
+        error: {
+          message: error.message,
+          name: error.name,
+          instructions: error.instructions,
+        },
+      })
+    );
+  }
+});
+
+process.on('unhandledRejection', reason => {
+  throw reason;
+});

--- a/src/targets/chrome/fetch-storybook.js
+++ b/src/targets/chrome/fetch-storybook.js
@@ -1,58 +1,51 @@
-const vm = require('vm');
-const debug = require('debug')('loki:chrome:fetchStories');
-const fetchUrl = require('./fetch-url');
-const getBrowserGlobals = require('./get-browser-globals');
+const cluster = require('cluster');
+const path = require('path');
 const { ServerError } = require('../../errors');
 
-async function createStorybookSandbox(baseUrl) {
-  debug(`Fetching iframe HTML and preview bundle JS from ${baseUrl}`);
-  const html = await fetchUrl(`${baseUrl}/iframe.html`);
-  const browser = getBrowserGlobals(html);
-  const scripts = browser.document.querySelectorAll('script[src]');
-  const previewSrc = Array.from(scripts)
-    .map(node => node.attributes.src.nodeValue)
-    .filter(src => src.match(/preview\.([a-f0-9]+\.)?bundle\.js/) !== -1)[0];
-
-  if (!previewSrc) {
-    throw new Error('Unable to locate preview bundle');
+function createError({ message, name, instructions }) {
+  switch (name) {
+    case 'ServerError':
+      return new ServerError(message, instructions);
+    default:
+      return new Error(message);
   }
-
-  const bundle = await fetchUrl(`${baseUrl}/${previewSrc}`);
-
-  debug('Creating js sandbox');
-  const sandbox = vm.createContext(browser);
-
-  debug('Executing storybook preview bundle');
-  vm.runInNewContext(bundle, sandbox);
-
-  return sandbox;
 }
 
-async function fetchStorybook(baseUrl = 'http://localhost:6006') {
-  let sandbox;
-  try {
-    sandbox = await createStorybookSandbox(baseUrl);
-  } catch (err) {
-    if (err.message && err.message.indexOf('ECONNREFUSED') !== -1) {
-      throw new ServerError(
-        'Failed fetching stories because the server is down',
-        `Try starting it with "yarn storybook" or pass the --port or --host arguments if it's not running at ${baseUrl}`
-      );
-    }
-    throw err;
-  }
+// Wrap this functionality in a killable sub process to be
+// able to avoid the main process waiting for storybook timers
+// running in the vm.
+function fetchStorybook(baseUrl = 'http://localhost:6006') {
+  return new Promise((resolve, reject) => {
+    cluster.setupMaster({
+      exec: path.join(__dirname, 'fetch-storybook-worker.js'),
+      silent: false,
+    });
 
-  const getStorybook = sandbox.window.loki && sandbox.window.loki.getStorybook;
-  if (!getStorybook) {
-    throw new Error(
-      "Loki addon not registered. Add `import 'loki/configure-react'` to your config.js file."
-    );
-  }
+    const worker = cluster.fork();
 
-  return getStorybook().map(component => ({
-    kind: component.kind,
-    stories: component.stories.map(story => story.name),
-  }));
+    worker.on('online', () => {
+      worker.send(baseUrl);
+    });
+
+    worker.on('message', message => {
+      const { error, storybook } = JSON.parse(message);
+      if (error) {
+        reject(createError(error));
+      } else {
+        resolve(storybook);
+      }
+      worker.kill();
+    });
+
+    worker.on('error', error => {
+      reject(error);
+      worker.kill();
+    });
+
+    worker.on('exit', code => {
+      reject(new Error(`Fetch storybook Worker exited with code ${code}`));
+    });
+  });
 }
 
 module.exports = fetchStorybook;

--- a/src/targets/chrome/get-browser-globals.js
+++ b/src/targets/chrome/get-browser-globals.js
@@ -5,7 +5,9 @@ function getBrowserGlobals(html) {
   const { window } = dom;
   const noop = function noop() {};
 
-  const EventSource = noop;
+  const EventSource = function() {
+    this.close = noop;
+  };
 
   const navigator = {
     userAgent: 'loki',


### PR DESCRIPTION
@felquis reported in #29 that loki would sometimes fail with error `TypeError: source.close is not a function`. Upon some investigation the problem was in two parts: 

1. `EventSource` wasn't properly mocked, thus calling `close` on an instance would cause it to crash. 
2. Storybook running in sandboxed VM would includes some retry logic with timers causing the shutdown of the loki process to be slow as it was waiting for all code to execute. 

This PR tries to adress this by running the storybook bundle in a sub process instead and by mocking the `close` method too.