### PR TITLE
Fixes hasReactNativeDependency() when the project has no dependencies in package.js

### DIFF
--- a/src/config/project-package.js
+++ b/src/config/project-package.js
@@ -10,7 +10,7 @@ function getProjectPackage() {
 }
 
 function hasReactNativeDependency(pkg) {
-  return !!(pkg.dependencies && pkg.dependencies['react-native'])
+  return !!(pkg.dependencies && pkg.dependencies['react-native']);
 }
 
 function hasVueDependency(pkg) {

--- a/src/config/project-package.js
+++ b/src/config/project-package.js
@@ -10,7 +10,7 @@ function getProjectPackage() {
 }
 
 function hasReactNativeDependency(pkg) {
-  return !!pkg.dependencies['react-native'];
+  return !!(pkg.dependencies && pkg.dependencies['react-native'])
 }
 
 function hasVueDependency(pkg) {

--- a/src/config/project-package.js
+++ b/src/config/project-package.js
@@ -9,20 +9,27 @@ function getProjectPackage() {
   return require(getProjectPackagePath());
 }
 
+function hasDependency(packageName, pkg = getProjectPackage()) {
+  return Boolean(
+    (pkg.dependencies && pkg.dependencies[packageName]) ||
+      (pkg.peerDependencies && pkg.peerDependencies[packageName])
+  );
+}
+
 function hasReactNativeDependency(pkg) {
-  return !!(pkg.dependencies && pkg.dependencies['react-native']);
+  return hasDependency('react-native', pkg);
 }
 
 function hasVueDependency(pkg) {
-  return !!pkg.dependencies.vue;
+  return hasDependency('vue', pkg);
 }
 
 function isReactNativeProject() {
-  return hasReactNativeDependency(getProjectPackage());
+  return hasDependency('react-native');
 }
 
 function isVueProject() {
-  return hasVueDependency(getProjectPackage());
+  return hasDependency('vue');
 }
 
 module.exports = {


### PR DESCRIPTION
This was an issue for us because we moved what dependencies we had to be peer-dependencies, thus breaking this function.