### PR TITLE
Throw if no stories were found

### DIFF
--- a/src/commands/test/run-tests.js
+++ b/src/commands/test/run-tests.js
@@ -87,6 +87,9 @@ async function runTests(flatConfigurations, options) {
             title: 'Fetch list of stories',
             task: async () => {
               storybook = await target.getStorybook();
+              if (storybook.length === 0) {
+                throw new Error('Error: No stories were found.');
+              }
             },
           },
           ...Object.values(


### PR DESCRIPTION
This most likely is a symptom of something going wrong, and should be considered an error.