### PR TITLE
add storybook/ui peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -77,6 +77,9 @@
     "wait-on": "^2.0.2",
     "ws": "^3.0.0"
   },
+  "peerDependencies {
+    "@storybook/ui": ">=3 <3.2.18"
+  },
   "devDependencies": {
     "babel-eslint": "^7.2.3",
     "babel-jest": "^20.0.3",


### PR DESCRIPTION
as per oblador/loki#51, loki currently throws an error when using storybook 3.2.18 or later.

> Could not parse url argument "?" to pushState against base URL "about:blank".