### PR TITLE
Add option to configure Listr in verbose mode

### DIFF
--- a/docs/command-line-arguments.md
+++ b/docs/command-line-arguments.md
@@ -1,10 +1,10 @@
 # Command line arguments
 
-If you run loki via `yarn` or `npm`, you need to make sure to prepend your argument list with `--` so that yarn passes them though to loki. You can also add `./node_modules/.bin` to your `PATH` to be able to run `loki` directly. 
+If you run loki via `yarn` or `npm`, you need to make sure to prepend your argument list with `--` so that yarn passes them though to loki. You can also add `./node_modules/.bin` to your `PATH` to be able to run `loki` directly.
 
 ## `loki test`
 
-Capture screenshots and compare them against the reference files. 
+Capture screenshots and compare them against the reference files.
 
 ```
 yarn loki test -- --port 9009
@@ -33,16 +33,17 @@ yarn loki test -- --port 9009
 |**`--configurationFilter`**|Regular expression for targets that should be tested.|*None*|
 |**`--targetFilter`**|Regular expression for targets that should be tested.|*None*|
 |**`--requireReference`**|Fail stories without reference image, useful for CI.|*No*|
+|**`--verboseRenderer`**|Plain text renderer, useful for CI.|*No*|
 
 ## `loki update`
 
-Capture screenshots and update the reference files. 
+Capture screenshots and update the reference files.
 
 Takes same arguments as `loki test`.
 
 ## `loki approve`
 
-Prunes old and updates reference files with the images generated in the last run. 
+Prunes old and updates reference files with the images generated in the last run.
 
 |Flag|Description|Default|
 |---|---|---|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -2,7 +2,7 @@
 
 The init command will add a `loki` section to your `package.json`, but you can edit it to your wishes. *NOTE*: Any command line argument that `loki test` accepts can also be added to the `loki` config object.
 
-Example `package.json`: 
+Example `package.json`:
 
 ```json
 {
@@ -37,7 +37,7 @@ This setting is a CSS selector to the part of the page you want screenshots of. 
 
 ## `diffingEngine`
 
-There are two currently available options to choose from when comparing images in loki: 
+There are two currently available options to choose from when comparing images in loki:
 
 ### `gm`
 
@@ -45,13 +45,17 @@ Uses the GraphicsMagick library to create diffs, this is generally faster but re
 
 ### `looks-same`
 
-A JavaScript only solution that will work out of the box on every machine, however it is slower and will produce a different diff image. 
+A JavaScript only solution that will work out of the box on every machine, however it is slower and will produce a different diff image.
 
 ||`gm`|`looks-same`|
 |-|---|------------|
-|**Dependency**|[GraphicsMagick](http://www.graphicsmagick.org)|None| 
-|**Speed**|🏃Fast|🚶Slower| 
-|**Output**|![](gm-diff.png)|![](looks-same-diff.png)| 
+|**Dependency**|[GraphicsMagick](http://www.graphicsmagick.org)|None|
+|**Speed**|🏃Fast|🚶Slower|
+|**Output**|![](gm-diff.png)|![](looks-same-diff.png)|
+
+## `verboseRenderer`
+
+Plain text output, useful for CI.
 
 ## ~~`skipStories`~~ **DEPRECATED**
 
@@ -61,7 +65,7 @@ This setting is deprecated, use `storiesOf().add.skip()` instead on the stories 
 
 ## `storiesFilter`
 
-Opposite to `skipStories`. 
+Opposite to `skipStories`.
 
 ## `configurations`
 

--- a/src/commands/test/parse-options.js
+++ b/src/commands/test/parse-options.js
@@ -5,11 +5,7 @@ const { dependencyAvailable } = require('../../dependency-detection');
 
 function parseOptions(args, config) {
   const argv = minimist(args, {
-    boolean: [
-      'requireReference',
-      'chromeEnableAnimations',
-      'verboseRenderer'
-    ],
+    boolean: ['requireReference', 'chromeEnableAnimations', 'verboseRenderer'],
   });
 
   const $ = key => argv[key] || config[key] || defaults[key];

--- a/src/commands/test/parse-options.js
+++ b/src/commands/test/parse-options.js
@@ -5,7 +5,11 @@ const { dependencyAvailable } = require('../../dependency-detection');
 
 function parseOptions(args, config) {
   const argv = minimist(args, {
-    boolean: ['requireReference', 'chromeEnableAnimations'],
+    boolean: [
+      'requireReference',
+      'chromeEnableAnimations',
+      'verboseRenderer'
+    ],
   });
 
   const $ = key => argv[key] || config[key] || defaults[key];
@@ -28,6 +32,7 @@ function parseOptions(args, config) {
     storiesFilter: $('storiesFilter'),
     diffingEngine:
       $('diffingEngine') || (dependencyAvailable('gm') ? 'gm' : 'looks-same'),
+    verboseRenderer: $('verboseRenderer'),
     requireReference: $('requireReference'),
     updateReference: argv._[0] === 'update',
     targetFilter: argv.targetFilter,

--- a/src/commands/test/run-tests.js
+++ b/src/commands/test/run-tests.js
@@ -115,7 +115,9 @@ async function runTests(flatConfigurations, options) {
                       task: () =>
                         getListr(options)(
                           stories.map(story => ({
-                            title: options.verboseRenderer ? `${kind}: ${story}` : story,
+                            title: options.verboseRenderer
+                              ? `${kind}: ${story}`
+                              : story,
                             task: () =>
                               testStory(
                                 target,

--- a/src/commands/test/run-tests.js
+++ b/src/commands/test/run-tests.js
@@ -115,7 +115,7 @@ async function runTests(flatConfigurations, options) {
                       task: () =>
                         getListr(options)(
                           stories.map(story => ({
-                            title: story,
+                            title: options.verboseRenderer ? `${kind}: ${story}` : story,
                             task: () =>
                               testStory(
                                 target,

--- a/src/commands/test/run-tests.js
+++ b/src/commands/test/run-tests.js
@@ -54,6 +54,14 @@ const filterStorybook = (storybook, excludePattern, includePattern) => {
     .filter(({ stories }) => stories.length !== 0);
 };
 
+const getListr = options => (tasks, listrOptions = {}) => {
+  const newOptions = listrOptions;
+  if (options.verboseRenderer) {
+    newOptions.renderer = 'verbose';
+  }
+  return new Listr(tasks, newOptions);
+};
+
 async function runTests(flatConfigurations, options) {
   if (options.updateReference) {
     await fs.ensureDir(options.referenceDir);
@@ -75,7 +83,7 @@ async function runTests(flatConfigurations, options) {
     return {
       title: name,
       task: () =>
-        new Listr([
+        getListr(options)([
           {
             title: 'Start',
             task: async ({ activeTargets }) => {
@@ -97,7 +105,7 @@ async function runTests(flatConfigurations, options) {
               (configuration, configurationName) => ({
                 title: `Test ${configurationName}`,
                 task: () =>
-                  new Listr(
+                  getListr(options)(
                     filterStorybook(
                       storybook,
                       options.skipStoriesPattern || configuration.skipStories,
@@ -105,7 +113,7 @@ async function runTests(flatConfigurations, options) {
                     ).map(({ kind, stories }) => ({
                       title: kind,
                       task: () =>
-                        new Listr(
+                        getListr(options)(
                           stories.map(story => ({
                             title: story,
                             task: () =>
@@ -189,7 +197,7 @@ async function runTests(flatConfigurations, options) {
     }
   };
 
-  const tasks = new Listr(
+  const tasks = getListr(options)(
     Object.values(map(createTargetTask, groupByTarget(flatConfigurations)))
   );
 


### PR DESCRIPTION
The default Listr renderer doesn't play well with non-TTY outputs.

By passing `--verboseRenderer`, we configure Listr to use their `verbose` renderer, which though not fancy, works well on CI.

![image](https://user-images.githubusercontent.com/697014/37650909-aafd9214-2c36-11e8-8930-562f7458ba2a.png)

Feedback is welcome :)