### PR TITLE
Add url to JSDOM constructor

### DIFF
--- a/src/targets/chrome/fetch-storybook-worker.js
+++ b/src/targets/chrome/fetch-storybook-worker.js
@@ -7,7 +7,7 @@ const { ServerError } = require('../../errors');
 async function createStorybookSandbox(baseUrl) {
   debug(`Fetching iframe HTML and preview bundle JS from ${baseUrl}`);
   const html = await fetchUrl(`${baseUrl}/iframe.html`);
-  const browser = getBrowserGlobals(html);
+  const browser = getBrowserGlobals(html, baseUrl);
   const scripts = browser.document.querySelectorAll('script[src]');
   const previewSrc = Array.from(scripts)
     .map(node => node.attributes.src.nodeValue)

--- a/src/targets/chrome/get-browser-globals.js
+++ b/src/targets/chrome/get-browser-globals.js
@@ -1,9 +1,10 @@
 const { JSDOM, VirtualConsole } = require('jsdom');
 
-function getBrowserGlobals(html) {
+function getBrowserGlobals(html, url) {
   const dom = new JSDOM(html, {
     virtualConsole: new VirtualConsole(),
     pretendToBeVisual: true,
+    url,
   });
   const { window } = dom;
   const noop = function noop() {};


### PR DESCRIPTION
Based on @priomsrb's comment, fixes https://github.com/oblador/loki/issues/51.

Tried it out with latest versions of storybook and works great.

Weirdly enough, we are not getting the "No stories were found." error.