### PR TITLE
Fix Listr not outputting gm errors

### DIFF
--- a/src/diffing/gm.js
+++ b/src/diffing/gm.js
@@ -9,7 +9,11 @@ function getImageDiff(path1, path2, diffPath, tolerance) {
       { file: diffPath, tolerance: tolerance / 100 },
       (err, isEqual) => {
         if (err) {
-          reject(err);
+          if (typeof err === 'string') {
+            reject(new Error(err));
+          } else {
+            reject(err);
+          }
         } else {
           if (isEqual) {
             fs.remove(diffPath);


### PR DESCRIPTION
Got weird undescriptive errors like below due to a broken GM installation. Turns out the `gm` library returns strings and not errors, so Listr wouldn't output them properly. 

<img width="232" alt="skarmavbild 2018-06-08 kl 12 45 16" src="https://user-images.githubusercontent.com/378279/41177690-d85da218-6b19-11e8-9dc1-f716e839fb52.png">
