### PR TITLE
Increase shared memory to 1gb

### DIFF
--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -78,6 +78,7 @@ function createChromeDockerTarget({
     ensureDependencyAvailable('docker');
     const args = runArgs
       .concat([
+        '--shm-size=1g',
         '-p',
         `${port}:${port}`,
         chromeDockerImage,


### PR DESCRIPTION
That helps to avoid crashes of the docker container, when the parallelism is high.

Should we maybe make it configurable, or would 1gb be ok for now?