### PR TITLE
Fix storiesOf monkey patch

### DIFF
--- a/src/targets/decorate-storybook.js
+++ b/src/targets/decorate-storybook.js
@@ -51,8 +51,20 @@ function decorateStorybook(storybook) {
     return stories;
   }
 
-  /* eslint no-param-reassign: ["error", { "props": false }] */
-  storybook.storiesOf = storiesOf;
+  // Monkey patch storiesOf to be able to add async/skip methods
+  const descriptor = Object.getOwnPropertyDescriptor(storybook, 'storiesOf');
+  if (descriptor.writable) {
+    /* eslint no-param-reassign: ["error", { "props": false }] */
+    storybook.storiesOf = storiesOf;
+  } else {
+    Object.defineProperty(storybook, 'storiesOf', {
+      configurable: true,
+      enumerable: true,
+      get: function() {
+        return storiesOf;
+      },
+    });
+  }
 
   function getStorybook() {
     return storybook.getStorybook().map(function(component) {

--- a/src/targets/decorate-storybook.js
+++ b/src/targets/decorate-storybook.js
@@ -57,6 +57,7 @@ function decorateStorybook(storybook) {
     /* eslint no-param-reassign: ["error", { "props": false }] */
     storybook.storiesOf = storiesOf;
   } else {
+    // In recent versions of storybook object this isn't writeable, probably due to babel transpilation changes
     Object.defineProperty(storybook, 'storiesOf', {
       configurable: true,
       enumerable: true,


### PR DESCRIPTION
Upgrading to a later version of storybook breaks skip/async methods, and this PR fixes that. 