### PR TITLE
Default chromeTolerance to be 0

### DIFF
--- a/docs/command-line-arguments.md
+++ b/docs/command-line-arguments.md
@@ -28,7 +28,7 @@ yarn loki test -- --port 9009
 |**`--chromeLoadTimeout`**|How many miliseconds loki will wait for the page to load before taking as screnshot.|`60000`|
 |**`--chromeRetries`**|The number of retries for taking the screenshot, in case of failure.|`0`|
 |**`--chromeSelector`**|CSS selector to the part of the DOM to screenshot. Useful you have decorators that should be excluded.|`#root > *`|
-|**`--chromeTolerance`**|How many percent tolerated difference compared to reference image.|`2.3`|
+|**`--chromeTolerance`**|How many percent tolerated difference compared to reference image. Behaviour of tolerance depends on `diffingEngine`.|`0`|
 |**`--skipStories`**|**DEPRECATED** Regular expression for stories that should not be tested, it will be tested against a string with the format `${kind} ${story}`.|*None*|
 |**`--storiesFilter`**|Opposite of `--skipStories`.|*None*|
 |**`--configurationFilter`**|Regular expression for targets that should be tested.|*None*|

--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -41,11 +41,11 @@ There are two currently available options to choose from when comparing images i
 
 ### `gm`
 
-Uses the GraphicsMagick library to create diffs, this is generally faster but requires to have the library installed. You can install it with homebrew using `brew install graphicsmagick`. This is default if available.
+Uses the GraphicsMagick library to create diffs, this is generally faster but requires to have the library installed. You can install it with homebrew using `brew install graphicsmagick`. This is default if available. `chromeTolerance` percentage is based on overall image, meaning you'd likely want a low threshold.
 
 ### `looks-same`
 
-A JavaScript only solution that will work out of the box on every machine, however it is slower and will produce a different diff image.
+A JavaScript only solution that will work out of the box on every machine, however it is slower and will produce a different diff image. `chromeTolerance` percentage is based on neighboring pixels which makes it ideal when you have different pixel densities.
 
 ||`gm`|`looks-same`|
 |-|---|------------|

--- a/src/commands/test/default-options.json
+++ b/src/commands/test/default-options.json
@@ -5,7 +5,7 @@
   "chromeLoadTimeout": "60000",
   "chromeRetries": "0",
   "chromeSelector": "#root > *",
-  "chromeTolerance": "2.3",
+  "chromeTolerance": "0",
   "host": "localhost",
   "output": "./.loki/current",
   "difference": "./.loki/difference",


### PR DESCRIPTION
**This is a breaking change**

If using docker screenshots are supposed to be as deterministic as possible, this setting should only be needed if you're using the chrome app on different platforms.

Related issue: https://github.com/oblador/loki/issues/69