### PR TITLE
Fix final output of failed url loading errors

### DIFF
--- a/src/cli.js
+++ b/src/cli.js
@@ -3,7 +3,11 @@
 const minimist = require('minimist');
 const { die, bold } = require('./console');
 const { version } = require('../package.json');
-const { MissingDependencyError, ServerError } = require('./errors');
+const {
+  MissingDependencyError,
+  ServerError,
+  FetchingURLsError,
+} = require('./errors');
 
 const getExecutorForCommand = command => {
   switch (command) {
@@ -34,7 +38,11 @@ async function run() {
   try {
     await executor(args);
   } catch (err) {
-    if (err instanceof MissingDependencyError || err instanceof ServerError) {
+    if (
+      err instanceof MissingDependencyError ||
+      err instanceof ServerError ||
+      err instanceof FetchingURLsError
+    ) {
       die(err.message, err.instructions);
     }
 


### PR DESCRIPTION
Fixes the **`[Object object]`** output after a request failed to load as shown in the screenshot in this issue: https://github.com/oblador/loki/issues/80