### PR TITLE
Be more graceful when the selector is not valid: take a screenshot of 'body' in that case.

### DIFF
--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -241,11 +241,11 @@ function createChromeTarget(
     const url = getStoryUrl(kind, story);
 
     const tab = await launchNewTab(tabOptions);
+    let screenshot;
     try {
       await withTimeout(options.chromeLoadTimeout)(tab.loadUrl(url));
-      const screenshot = await tab.captureScreenshot(selector);
+      screenshot = await tab.captureScreenshot(selector);
       await fs.outputFile(outputPath, screenshot);
-      return screenshot;
     } catch (err) {
       if (err instanceof TimeoutError) {
         debug(`Timed out waiting for "${url}" to load`);
@@ -255,6 +255,8 @@ function createChromeTarget(
     } finally {
       await tab.close();
     }
+
+    return screenshot;
   }
 
   return {

--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -167,6 +167,12 @@ function createChromeTarget(
           debug(`Getting viewport position of "${selector}"`);
           const position = await getPositionInViewport(selector);
 
+          if (position.width === 0 || position.height === 0) {
+            throw new Error(
+              `Selector "${selector} has zero width or height. Can't capture screenshot.`
+            );
+          }
+
           debug('Capturing screenshot');
           const clip = Object.assign({ scale: 1 }, position);
           const screenshot = await Page.captureScreenshot({

--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -171,12 +171,6 @@ function createChromeTarget(
             );
           }
 
-          if (position.width === 0 || position.height === 0) {
-            throw new Error(
-              `Selector "${selector} has zero width or height. Can't capture screenshot.`
-            );
-          }
-
           debug('Capturing screenshot');
           const clip = Object.assign({ scale: 1 }, position);
           const screenshot = await Page.captureScreenshot({

--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -237,17 +237,18 @@ function createChromeTarget(
     const tab = await launchNewTab(tabOptions);
     try {
       await withTimeout(options.chromeLoadTimeout)(tab.loadUrl(url));
+      const screenshot = await tab.captureScreenshot(selector);
+      await fs.outputFile(outputPath, screenshot);
+      return screenshot;
     } catch (err) {
       if (err instanceof TimeoutError) {
         debug(`Timed out waiting for "${url}" to load`);
       } else {
         throw err;
       }
+    } finally {
+      await tab.close();
     }
-    const screenshot = await tab.captureScreenshot(selector);
-    await fs.outputFile(outputPath, screenshot);
-    await tab.close();
-    return screenshot;
   }
 
   return {

--- a/src/targets/chrome/get-selector-box-size.js
+++ b/src/targets/chrome/get-selector-box-size.js
@@ -12,7 +12,7 @@ const getSelectorBoxSize = (window, selector) => {
     return !isWrapper;
   };
 
-  const isVisisble = element => {
+  const isVisible = element => {
     const style = window.getComputedStyle(element);
 
     return !(
@@ -45,11 +45,15 @@ const getSelectorBoxSize = (window, selector) => {
     };
   };
 
-  return elements
+  const filteredElements = elements
     .filter(isNotWrapperElement)
-    .filter(isVisisble)
-    .map(getBoundingClientRect)
-    .reduce(boxSizeUnion);
+    .filter(isVisible);
+
+  if (filteredElements.length > 0) {
+    return filteredElements.map(getBoundingClientRect).reduce(boxSizeUnion);
+  }
+
+  throw new Error('Unable to find a visible, non-wrapper element');
 };
 
 module.exports = getSelectorBoxSize;


### PR DESCRIPTION
Sometimes my stories look fine in the browser, but Loki complains that the selector isn't valid.

This can happen in many cases. For example: if my component is absolutely positioned, then the selector would have a 0 width and height. In those cases it might be better to just capture a screenshot of the entire body rather than throw an error.

One of the things I like about Loki is that it requires minimal configuration and tweaking to get it working. So I think it should avoid throwing errors if the story looks fine in the user's browser.