### PR TITLE
Maintain access to resolveAssetSource after monkey-patch

### DIFF
--- a/package.json
+++ b/package.json
@@ -53,6 +53,7 @@
     "fs-extra": "^7.0.1",
     "get-port": "^4.0.0",
     "gm": "^1.23.1",
+    "hoist-non-react-statics": "^3.2.1",
     "listr": "^0.14.3",
     "looks-same": "^4.0.0",
     "minimist": "^1.2.0",

--- a/src/targets/native/ready-state-emitting-image.js
+++ b/src/targets/native/ready-state-emitting-image.js
@@ -4,6 +4,7 @@
  */
 const React = require('react');
 const Image = require('react-native/Libraries/Image/Image');
+const hoistNonReactStatics = require('hoist-non-react-statics');
 const { registerPendingPromise } = require('../ready-state-manager');
 
 const IMAGE_LOAD_TIMEOUT = 20000;
@@ -64,8 +65,6 @@ class ReadyStateEmittingImage extends React.Component {
   }
 }
 
-ReadyStateEmittingImage.propTypes = Image.propTypes;
-ReadyStateEmittingImage.prefetch = Image.prefetch;
-ReadyStateEmittingImage.getSize = Image.getSize;
+hoistNonReactStatics(ReadyStateEmittingImage, Image);
 
 module.exports = ReadyStateEmittingImage;

--- a/yarn.lock
+++ b/yarn.lock
@@ -2582,6 +2582,13 @@ hoek@6.x.x:
   resolved "https://registry.yarnpkg.com/hoek/-/hoek-6.1.2.tgz#99e6d070561839de74ee427b61aa476bd6bddfd6"
   integrity sha512-6qhh/wahGYZHFSFw12tBbJw5fsAhhwrrG/y3Cs0YMTv2WzMnL0oLPnQJjv1QJvEfylRSOFuP+xCu+tdx0tD16Q==
 
+hoist-non-react-statics@^3.2.1:
+  version "3.2.1"
+  resolved "https://registry.yarnpkg.com/hoist-non-react-statics/-/hoist-non-react-statics-3.2.1.tgz#c09c0555c84b38a7ede6912b61efddafd6e75e1e"
+  integrity sha512-TFsu3TV3YLY+zFTZDrN8L2DTFanObwmBLpWvJs1qfUuEQ5bTAdFcwfx2T/bsCXfM9QHSLvjfP+nihEl0yvozxw==
+  dependencies:
+    react-is "^16.3.2"
+
 home-or-tmp@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/home-or-tmp/-/home-or-tmp-2.0.0.tgz#e36c3f2d2cae7d746a857e38d18d5f32a7882db8"
@@ -5161,6 +5168,11 @@ rc@^1.2.7:
     ini "~1.3.0"
     minimist "^1.2.0"
     strip-json-comments "~2.0.1"
+
+react-is@^16.3.2:
+  version "16.6.3"
+  resolved "https://registry.yarnpkg.com/react-is/-/react-is-16.6.3.tgz#d2d7462fcfcbe6ec0da56ad69047e47e56e7eac0"
+  integrity sha512-u7FDWtthB4rWibG/+mFbVd5FvdI20yde86qKGx4lVUTWmPlSWQ4QxbBIrrs+HnXGbxOUlUzTAP/VDmvCwaP2yA==
 
 read-cmd-shim@~1.0.1:
   version "1.0.1"


### PR DESCRIPTION
Currently using `Image.resolveAssetSource` is not possible as the ready state emitting Image monkey patch does not re-export it.

![image](https://user-images.githubusercontent.com/224373/49698273-9048c100-fc15-11e8-889e-b596abe862d5.png)


This resolves this issue.