### PR TITLE
Remove the StatusBar controls and force the implementor to do it at Storybook mount time

### DIFF
--- a/docs/SUMMARY.md
+++ b/docs/SUMMARY.md
@@ -10,4 +10,5 @@
   * [loki init](command-line-arguments.md#loki-init)
 * [Continuous integration](continuous-integration.md)
 * [Handling flaky tests](flaky-tests.md)
+* [React Native](react-native.md)
 

--- a/docs/react-native.md
+++ b/docs/react-native.md
@@ -1,0 +1,12 @@
+## React Native
+
+Generally, loki supports React Native out of the box. The existence of the status bar causes a number of flakey tests, as such, it is recommended
+to disable the status bar where ever you invoke the `<Storybook />` component. 
+
+
+```
+import {StatusBar} from 'react-native';
+
+<StatusBar hidden />
+<Storybook />
+```

--- a/src/targets/native/configure-storybook.js
+++ b/src/targets/native/configure-storybook.js
@@ -104,13 +104,11 @@ async function configureStorybook() {
     );
 
   const originalState = {
-    statusBarHidden: false, // TODO: get actual value
     disableYellowBox: console.disableYellowBox, // eslint-disable-line no-console
   };
 
   const restore = () => {
     customErrorHandler = null;
-    ReactNative.StatusBar.setHidden(originalState.statusBarHidden);
     // eslint-disable-next-line no-console
     console.disableYellowBox = originalState.disableYellowBox;
   };
@@ -134,7 +132,6 @@ async function configureStorybook() {
     if (hasDevSettings) {
       DevSettings.setHotLoadingEnabled(false);
     }
-    ReactNative.StatusBar.setHidden(true, 'none');
     // eslint-disable-next-line no-console
     console.disableYellowBox = true;
   };


### PR DESCRIPTION
I have had issues with the StatusBar re-appearing. 

There appears to be a half-implemented status bar control (the cache is never set). I think the easiest approach is to remove this, and allow the controls of it where you invoke `<Storybook />`