### PR TITLE
Add option to run docker commands with sudo

### DIFF
--- a/docs/command-line-arguments.md
+++ b/docs/command-line-arguments.md
@@ -36,6 +36,7 @@ yarn loki test -- --port 9009
 | **`--targetFilter`**           | Regular expression for targets that should be tested.                                                                                           | _None_                                       |
 | **`--requireReference`**       | Fail stories without reference image, useful for CI.                                                                                            | _False, true for CI_                         |
 | **`--verboseRenderer`**        | Plain text renderer, useful for CI.                                                                                                             | _False, true for CI_                         |
+| **`--dockerWithSudo`**        | Run docker commands with sudo                                                                                                             | `false`                         |
 
 ## `loki update`
 

--- a/src/commands/test/parse-options.js
+++ b/src/commands/test/parse-options.js
@@ -11,7 +11,7 @@ function parseOptions(args, config) {
       'requireReference',
       'chromeEnableAnimations',
       'verboseRenderer',
-      'dockerAsSudo',
+      'dockerWithSudo',
     ],
   });
 
@@ -45,7 +45,7 @@ function parseOptions(args, config) {
     updateReference: argv._[0] === 'update',
     targetFilter: argv.targetFilter,
     configurationFilter: argv.configurationFilter || argv._[1],
-    dockerAsSudo: $('dockerAsSudo'),
+    dockerWithSudo: $('dockerWithSudo'),
   };
 }
 

--- a/src/commands/test/parse-options.js
+++ b/src/commands/test/parse-options.js
@@ -7,7 +7,12 @@ const getAbsoluteURL = require('./get-absolute-url');
 
 function parseOptions(args, config) {
   const argv = minimist(args, {
-    boolean: ['requireReference', 'chromeEnableAnimations', 'verboseRenderer'],
+    boolean: [
+      'requireReference',
+      'chromeEnableAnimations',
+      'verboseRenderer',
+      'dockerAsSudo',
+    ],
   });
 
   const $ = key => argv[key] || config[key] || defaults[key];
@@ -40,6 +45,7 @@ function parseOptions(args, config) {
     updateReference: argv._[0] === 'update',
     targetFilter: argv.targetFilter,
     configurationFilter: argv.configurationFilter || argv._[1],
+    dockerAsSudo: $('dockerAsSudo'),
   };
 }
 

--- a/src/commands/test/run-tests.js
+++ b/src/commands/test/run-tests.js
@@ -180,6 +180,7 @@ async function runTests(flatConfigurations, options) {
             baseUrl: options.reactUri,
             chromeDockerImage: options.chromeDockerImage,
             chromeFlags: options.chromeFlags,
+            dockerAsSudo: options.dockerAsSudo,
           }),
           configurations,
           options.chromeConcurrency,

--- a/src/commands/test/run-tests.js
+++ b/src/commands/test/run-tests.js
@@ -180,7 +180,7 @@ async function runTests(flatConfigurations, options) {
             baseUrl: options.reactUri,
             chromeDockerImage: options.chromeDockerImage,
             chromeFlags: options.chromeFlags,
-            dockerAsSudo: options.dockerAsSudo,
+            dockerWithSudo: options.dockerWithSudo,
           }),
           configurations,
           options.chromeConcurrency,

--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -190,8 +190,8 @@ function createChromeDockerTarget({
 
   process.on('SIGINT', () => {
     if (dockerId) {
-      const maybeSudo = dockerWithSudo ? 'sudo' : '';
-      execSync(`${maybeSudo}${dockerPath} docker kill ${dockerId}`);
+      const maybeSudo = dockerWithSudo ? 'sudo ' : '';
+      execSync(`${maybeSudo}${dockerPath} kill ${dockerId}`);
     }
   });
 

--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -9,8 +9,8 @@ const getRandomPort = require('get-port');
 const { ensureDependencyAvailable } = require('../../dependency-detection');
 const createChromeTarget = require('./create-chrome-target');
 
-const getExecutor = dockerAsSudo => (dockerPath, args) => {
-  if (dockerAsSudo) {
+const getExecutor = dockerWithSudo => (dockerPath, args) => {
+  if (dockerWithSudo) {
     return execa('sudo', [dockerPath, ...args]);
   }
 
@@ -80,7 +80,7 @@ function createChromeDockerTarget({
   baseUrl = 'http://localhost:6006',
   chromeDockerImage = 'yukinying/chrome-headless',
   chromeFlags = ['--headless', '--disable-gpu', '--hide-scrollbars'],
-  dockerAsSudo = false,
+  dockerWithSudo = false,
 }) {
   let port;
   let dockerId;
@@ -88,7 +88,7 @@ function createChromeDockerTarget({
   let dockerUrl = baseUrl;
   const dockerPath = 'docker';
   const runArgs = ['run', '--rm', '-d', '-P'];
-  const execute = getExecutor(dockerAsSudo);
+  const execute = getExecutor(dockerWithSudo);
 
   if (!process.env.CI) {
     runArgs.push(`--security-opt=seccomp=${__dirname}/docker-seccomp.json`);
@@ -190,7 +190,7 @@ function createChromeDockerTarget({
 
   process.on('SIGINT', () => {
     if (dockerId) {
-      const maybeSudo = dockerAsSudo ? 'sudo' : '';
+      const maybeSudo = dockerWithSudo ? 'sudo' : '';
       execSync(`${maybeSudo}${dockerPath} docker kill ${dockerId}`);
     }
   });


### PR DESCRIPTION
Unfortunately in our Jenkins CI we are restricted an only able to run `docker` commands with `sudo`, because of this loki is unable to run with the `chrome.docker` target.

This PR adds a `dockerAsSudo` option to resolve this, it'll run all `docker` commands with `sudo` prepended if the option has been specified.

More than happy to take feedback & answer any questions!