### PR TITLE
Fix "Reduce of empty array with no initial value" when elements are invisible

### DIFF
--- a/src/targets/chrome/create-chrome-target.js
+++ b/src/targets/chrome/create-chrome-target.js
@@ -161,7 +161,7 @@ function createChromeTarget(
       try {
         return await executeFunctionWithWindow(getSelectorBoxSize, selector);
       } catch (error) {
-        if (error.message === 'Unable to find selector') {
+        if (error.message === 'No visible elements found') {
           throw new Error(
             `Unable to get position of selector "${selector}". Review the \`chromeSelector\` option and make sure your story doesn't crash.`
           );

--- a/src/targets/chrome/get-selector-box-size.js
+++ b/src/targets/chrome/get-selector-box-size.js
@@ -1,12 +1,6 @@
 const getSelectorBoxSize = (window, selector) => {
-  const elements = [...window.document.querySelectorAll(selector)];
-
-  if (elements.length === 0) {
-    throw new Error('Unable to find selector');
-  }
-
-  const isNotWrapperElement = element => {
-    const isWrapper = elements.some(node =>
+  const isNotWrapperElement = (element, index, array) => {
+    const isWrapper = array.some(node =>
       node === element ? false : element.contains(node)
     );
     return !isWrapper;
@@ -23,6 +17,14 @@ const getSelectorBoxSize = (window, selector) => {
       style.height === '0px'
     );
   };
+
+  const elements = Array.from(window.document.querySelectorAll(selector))
+    .filter(isVisisble)
+    .filter(isNotWrapperElement);
+
+  if (elements.length === 0) {
+    throw new Error('No visible elements found');
+  }
 
   const getBoundingClientRect = element => element.getBoundingClientRect();
 
@@ -45,11 +47,7 @@ const getSelectorBoxSize = (window, selector) => {
     };
   };
 
-  return elements
-    .filter(isNotWrapperElement)
-    .filter(isVisisble)
-    .map(getBoundingClientRect)
-    .reduce(boxSizeUnion);
+  return elements.map(getBoundingClientRect).reduce(boxSizeUnion);
 };
 
 module.exports = getSelectorBoxSize;


### PR DESCRIPTION
In some edge cases we filter out elements matching the selector and thus can't determine a size. Currently it fails with the cryptic `Reduce of empty array with no initial value`. This PR changes this to a more user friendly error message as well as another edge case where `isNotWrapperElement` would not take invisible elements into consideration. 