### PR TITLE
Add retries to chrome getStorybook

### DIFF
--- a/src/failure-handling.js
+++ b/src/failure-handling.js
@@ -40,9 +40,21 @@ const withRetries = (maxRetries = 3) => fn => async (...args) => {
       lastError = err;
     }
   }
-  const error = new Error(`Failed with "${lastError}" after ${tries} tries`);
+  const message = lastError.message || lastError.toString();
+  const error = new Error(`Failed with "${message}" after ${tries} tries`);
   error.originalError = lastError;
   throw error;
 };
 
-module.exports = { withTimeout, withRetries, TimeoutError };
+function unwrapError(rawError) {
+  let error = rawError;
+
+  // Unwrap retry/timeout errors
+  while (error.originalError) {
+    error = error.originalError;
+  }
+
+  return error;
+}
+
+module.exports = { withTimeout, withRetries, unwrapError, TimeoutError };

--- a/src/targets/chrome/create-chrome-target.spec.js
+++ b/src/targets/chrome/create-chrome-target.spec.js
@@ -54,10 +54,8 @@ describe('createChromeTarget', () => {
     it(
       'throws if not configured',
       async () => {
-        await expect(fetchStorybookFixture('unconfigured')).rejects.toEqual(
-          new Error(
-            "Loki addon not registered. Add `import 'loki/configure-react'` to your config.js file."
-          )
+        await expect(fetchStorybookFixture('unconfigured')).rejects.toThrow(
+          "Loki addon not registered. Add `import 'loki/configure-react'` to your config.js file."
         );
       },
       DOCKER_TEST_TIMEOUT
@@ -68,9 +66,7 @@ describe('createChromeTarget', () => {
       async () => {
         await expect(
           fetchStorybookUrl('http://localhost:23456')
-        ).rejects.toEqual(
-          new Error('Failed fetching stories because the server is down')
-        );
+        ).rejects.toThrow('Failed fetching stories because the server is down');
       },
       DOCKER_TEST_TIMEOUT
     );


### PR DESCRIPTION
I get an intermittent `Socket hang up` error when fetching stories from storybook, there's no real pattern to it and it happens on all versions of chrome that I tested, but maybe 1% of the time. There's a few [long standing issues reported in CDP](https://github.com/cyrus-and/chrome-remote-interface/issues/58) but they go nowhere as it's hard to reproduce. 

This PR takes the a bit lazy pragmatic approach of adding a few retries to this function. I'm unsure if this is enough to resolve it, but time will tell :-)