### PR TITLE
Fix issue with lack of execute

### DIFF
--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -165,7 +165,7 @@ function createChromeDockerTarget({
         errorLogs.push(chunk);
       });
 
-      host = await getNetworkHost(dockerId);
+      host = await getNetworkHost(execute, dockerId);
       try {
         await waitOnCDPAvailable(host, port);
       } catch (error) {


### PR DESCRIPTION
During: https://github.com/oblador/loki/commit/d5215172d2da54a8774b25094281d120a7f77cd8#diff-b75c1e1e6b0fa125e76a9f03fe7716c5R167 an error has been made and `execute` is not passed anymore to `getNetworHost` function which causes an error like below:

![Screenshot 2019-07-10 at 13 25 11](https://user-images.githubusercontent.com/3391674/60966257-1c3fda00-a318-11e9-9717-810165fe022b.png)

This PR should fix this issue.