### PR TITLE
Adding Image.propTypes to ready-state-emitting-image to work with react-native-video

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "loki",
-  "version": "0.17.0",
+  "version": "0.17.1",
   "description": "Visual Regression Testing for react-storybook",
   "main": "index.js",
   "bin": {

--- a/src/targets/native/ready-state-emitting-image.js
+++ b/src/targets/native/ready-state-emitting-image.js
@@ -30,6 +30,8 @@ class ReadyStateEmittingImage extends React.Component {
     }
   }
 
+  static propTypes = Image.propTypes
+
   componentWillUnmount() {
     clearTimeout(this.timer);
   }


### PR DESCRIPTION
react-native-video sets up it's propTypes by using `Image.propTypes.resizeMode`. 

`ready-state-emitting-image` does not have propTypes specified, so this causes `react-native-video` to crash when used with loki.

This PR fixes the issue mentioned by adding propTypes onto the `ready-state-emitting-image`