### PR TITLE
Add outputFilenamesLowercase option

### DIFF
--- a/docs/command-line-arguments.md
+++ b/docs/command-line-arguments.md
@@ -38,6 +38,7 @@ yarn loki test -- --port 9009
 | **`--requireReference`**           | Fail stories without reference image, useful for CI.                                                                                            | _False, true for CI_                         |
 | **`--verboseRenderer`**            | Plain text renderer, useful for CI.                                                                                                             | _False, true for CI_                         |
 | **`--dockerWithSudo`**             | Run docker commands with sudo.                                                                                                                  | `false`                                      |
+| **`--outputFilenamesLowercase`**   | Output all filenames in lowercase format.                                                                                                       | `false`                                      |
 
 ## `loki update`
 

--- a/src/commands/test/default-options.json
+++ b/src/commands/test/default-options.json
@@ -10,6 +10,7 @@
   "output": "./.loki/current",
   "difference": "./.loki/difference",
   "reference": "./.loki/reference",
+  "outputFilenamesLowercase": false,
   "reactPort": "6006",
   "reactNativePort": "7007",
   "looksSame": {},

--- a/src/commands/test/parse-options.js
+++ b/src/commands/test/parse-options.js
@@ -22,6 +22,7 @@ function parseOptions(args, config) {
     outputDir: path.resolve($('output')),
     referenceDir: path.resolve($('reference')),
     differenceDir: path.resolve($('difference')),
+    outputFilenamesLowercase: $('outputFilenamesLowercase'),
     reactUri:
       getAbsoluteURL($('reactUri')) ||
       `http://${$('host')}:${argv.port || $('reactPort')}`,

--- a/src/commands/test/test-story.js
+++ b/src/commands/test/test-story.js
@@ -4,13 +4,16 @@ const { slugify } = require('transliteration');
 const { ReferenceImageError } = require('../../errors');
 const { getImageDiffer } = require('../../diffing');
 
-const SLUGIFY_OPTIONS = {
-  lowercase: false,
-  separator: '_',
-};
-
-const getBaseName = (configurationName, kind, story) =>
-  slugify(`${configurationName} ${kind} ${story}`, SLUGIFY_OPTIONS);
+const getBaseName = (
+  configurationName,
+  kind,
+  story,
+  outputFilenamesLowercase
+) =>
+  slugify(`${configurationName} ${kind} ${story}`, {
+    lowercase: outputFilenamesLowercase,
+    separator: '_',
+  });
 
 async function testStory(
   target,
@@ -21,7 +24,12 @@ async function testStory(
   kind,
   story
 ) {
-  const basename = getBaseName(configurationName, kind, story);
+  const basename = getBaseName(
+    configurationName,
+    kind,
+    story,
+    options.outputFilenamesLowercase
+  );
   const filename = `${basename}.png`;
   const outputPath = `${options.outputDir}/${filename}`;
   const referencePath = `${options.referenceDir}/${filename}`;

--- a/src/commands/test/test-story.spec.js
+++ b/src/commands/test/test-story.spec.js
@@ -43,6 +43,7 @@ describe('testStory', () => {
     it('adds reference image if requireReference option is false', async () => {
       const options = {
         requireReference: false,
+        outputFilenamesLowercase: false,
         outputDir: `${__dirname}/outputDir`,
         referenceDir: `${__dirname}/referenceDir`,
         differenceDir: `${__dirname}/differenceDir`,
@@ -51,6 +52,30 @@ describe('testStory', () => {
       await executeWithOptions(options);
 
       const referencePath = `${options.referenceDir}/${filename}`;
+
+      expect(target.captureScreenshotForStory).toHaveBeenCalledWith(
+        kind,
+        story,
+        referencePath,
+        options,
+        configuration
+      );
+    });
+
+    it('output filename is lowercase if outputFilenamesLowercase is set to true', async () => {
+      const options = {
+        outputFilenamesLowercase: true,
+        requireReference: false,
+        outputDir: `${__dirname}/outputDir`,
+        referenceDir: `${__dirname}/referenceDir`,
+        differenceDir: `${__dirname}/differenceDir`,
+      };
+
+      await executeWithOptions(options);
+
+      const referencePath = `${
+        options.referenceDir
+      }/configuration_kind_story.png`;
 
       expect(target.captureScreenshotForStory).toHaveBeenCalledWith(
         kind,
@@ -81,6 +106,7 @@ describe('testStory', () => {
       const options = {
         updateReference: false,
         requireReference: false,
+        outputFilenamesLowercase: false,
         outputDir: `${__dirname}/outputDir`,
         referenceDir: `${__dirname}/referenceDir`,
         differenceDir: `${__dirname}/differenceDir`,


### PR DESCRIPTION
`outputFilenamesLowercase` option, when set to true, forces all output filenames to be lowercase. This is useful for operating systems with case insensitive file systems.

Fixes #164