### PR TITLE
Retry all docker createNewDebuggerInstance calls with backup

### DIFF
--- a/src/failure-handling.js
+++ b/src/failure-handling.js
@@ -28,7 +28,9 @@ const withTimeout = (timeout, operationName) => fnOrPromise => {
   return awaitPromise(fnOrPromise);
 };
 
-const withRetries = (maxRetries = 3) => fn => async (...args) => {
+const sleep = duration => new Promise(resolve => setTimeout(resolve, duration));
+
+const withRetries = (maxRetries = 3, backoff = 0) => fn => async (...args) => {
   let tries = 0;
   let lastError;
   while (tries <= maxRetries) {
@@ -38,6 +40,9 @@ const withRetries = (maxRetries = 3) => fn => async (...args) => {
       return result;
     } catch (err) {
       lastError = err;
+    }
+    if (backoff) {
+      await sleep(backoff * tries);
     }
   }
   const message = lastError.message || lastError.toString();

--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -7,6 +7,7 @@ const CDP = require('chrome-remote-interface');
 const fs = require('fs-extra');
 const getRandomPort = require('get-port');
 const { ensureDependencyAvailable } = require('../../dependency-detection');
+const { withRetries } = require('../../failure-handling');
 const { ChromeError } = require('../../errors');
 const createChromeTarget = require('./create-chrome-target');
 
@@ -200,7 +201,7 @@ function createChromeDockerTarget({
     }
   }
 
-  async function createNewDebuggerInstance() {
+  const createNewDebuggerInstance = withRetries(3, 500)(async () => {
     debug(`Launching new tab with debugger at port ${host}:${port}`);
     const target = await CDP.New({ host, port });
     debug(`Launched with target id ${target.id}`);
@@ -212,7 +213,7 @@ function createChromeDockerTarget({
     };
 
     return client;
-  }
+  });
 
   process.on('SIGINT', () => {
     if (dockerId) {


### PR DESCRIPTION
Fixes `socket hang up` in some cases. 