### PR TITLE
Pass missing execute to getNetworkHost

### DIFF
--- a/src/targets/chrome/docker.js
+++ b/src/targets/chrome/docker.js
@@ -165,7 +165,7 @@ function createChromeDockerTarget({
         errorLogs.push(chunk);
       });
 
-      host = await getNetworkHost(dockerId);
+      host = await getNetworkHost(execute, dockerId);
       try {
         await waitOnCDPAvailable(host, port);
       } catch (error) {


### PR DESCRIPTION
The signature of getNetworkHost changed, but the only call to it was not adapted.