### PR TITLE
Fix Travis: Run example installation before script instead of before install

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -13,7 +13,7 @@ jobs:
     - stage: test
       services:
         - docker
-      before_install:
+      before_script:
         - cd examples/react && npm install
       name: 'Visual tests: React DOM'
       script: npm run test-ci


### PR DESCRIPTION
I'm not sure why this started failing all of a sudden, but most likely due to some breaking change in Travis. Should probably move away from it eventually given recent events. 