### PR TITLE
Fix loki logo URL in visual tests

### DIFF
--- a/examples/react/src/Logo.js
+++ b/examples/react/src/Logo.js
@@ -18,7 +18,7 @@ Logo.propTypes = {
 
 Logo.defaultProps = {
   delay: 0,
-  logoUrl: 'https://loki.js.org/favicon.png',
+  logoUrl: 'https://loki.js.org/img/favicon.png',
 };
 
 export default Logo;


### PR DESCRIPTION
This was due to the docs revamp. 