### PR TITLE
Fix looks-same config params reading

### DIFF
--- a/packages/runner/src/commands/test/parse-options.js
+++ b/packages/runner/src/commands/test/parse-options.js
@@ -40,7 +40,7 @@ function parseOptions(args, config) {
     diffingEngine:
       $('diffingEngine') || (dependencyAvailable('gm') ? 'gm' : 'looks-same'),
     fetchFailIgnore: $('fetchFailIgnore'),
-    looksSame: $('looksSame'),
+    'looks-same': $('looks-same'),
     gm: $('gm'),
     verboseRenderer: $('verboseRenderer'),
     requireReference: $('requireReference') || ciInfo.isCI,


### PR DESCRIPTION
Hi!

It seems #127 had a bug when it was merged. 

The docs say the config parameter in `package.json` should be `looks-same` (https://github.com/oblador/loki/blame/master/docs/configuration.md#L48), but currently that's not what gets read.

[Here](https://github.com/oblador/loki/blame/master/docs/configuration.md#L48) it's reading `looksSame` instead of `looks-same`, and storing it as a key `looksSame` also in the parsed configuration.

Later, when creating the diffing engine [here](https://github.com/oblador/loki/blob/master/packages/runner/src/commands/test/test-story.js#L49-L52), the it tries to get a config key with the same name as the `diffingEngine` given, which is never `looksSame`, but instead is either `gm` or `looks-same`. As a result, the config for `looks-same` never gets passed through.

This PR just changes the config parsing to read it the same way as it got documented, and stores it in the parsed config the same way too, since it will get read that way.

There are other options to fix this, but this one seemed to be the less invasive one.