### PR TITLE
Add fileNameFormatter config

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -92,6 +92,20 @@ Opposite to `skipStories`.
 
 The default behaviour of Loki is to fail a test if the story makes a network requests that fails. This setting is a regular expression, if the URL of a failed request matches it, the test will not fail, overriding the default behaviour.
 
+## `fileNameFormatter`
+
+By default loki will produce a flat file structure, but if you want to have hiearchy or make all names lower case you can pass a custom formatter function. It should return a string _without_ an extension and takes an object with these properties: `configurationName, kind, story`.
+
+Since JSON doesn't support functions, you need to be using the `loki.config.js` to configure your project, like so:
+
+```js
+module.exports = {
+  // ...other config goes here
+  fileNameFormatter: ({ configurationName, kind, story }) =>
+    `${configurationName}/${kind} ${story}`.toLowerCase(),
+};
+```
+
 ## `configurations`
 
 | Name                                 | Type      | Description                                                                                                                                               | Targets      |

--- a/packages/runner/src/commands/test/compare-screenshot.js
+++ b/packages/runner/src/commands/test/compare-screenshot.js
@@ -9,7 +9,7 @@ const SLUGIFY_OPTIONS = {
   separator: '_',
 };
 
-const getBaseName = (configurationName, kind, story) =>
+const defaultFileNameFormatter = ({ configurationName, kind, story }) =>
   slugify(`${configurationName} ${kind} ${story}`, SLUGIFY_OPTIONS);
 
 async function compareScreenshot(
@@ -20,7 +20,8 @@ async function compareScreenshot(
   kind,
   story
 ) {
-  const basename = getBaseName(configurationName, kind, story);
+  const getBaseName = options.fileNameFormatter || defaultFileNameFormatter;
+  const basename = getBaseName({ configurationName, kind, story });
   const filename = `${basename}.png`;
   const outputPath = `${options.outputDir}/${filename}`;
   const referencePath = `${options.referenceDir}/${filename}`;

--- a/packages/runner/src/commands/test/parse-options.js
+++ b/packages/runner/src/commands/test/parse-options.js
@@ -21,6 +21,7 @@ function parseOptions(args, config) {
     outputDir: path.resolve($('output')),
     referenceDir: path.resolve($('reference')),
     differenceDir: path.resolve($('difference')),
+    fileNameFormatter: config.fileNameFormatter,
     reactUri:
       $('reactUri') || `http://${$('host')}:${argv.port || $('reactPort')}`,
     reactNativeUri: `ws://${$('host')}:${argv.port || $('reactNativePort')}`,


### PR DESCRIPTION
Thanks to the new non-JSON based config support, we're able to take a custom file name formatter as a config option. 

Fixes #164, #165, #208.