### PR TITLE
Wait between retries when launching stories tab.

### DIFF
--- a/packages/target-chrome-core/src/create-chrome-target.js
+++ b/packages/target-chrome-core/src/create-chrome-target.js
@@ -17,6 +17,7 @@ const {
 } = require('@loki/core');
 const presets = require('./presets.json');
 
+const RETRY_LOADING_STORIES_TIMEOUT = 10000;
 const LOADING_STORIES_TIMEOUT = 60000;
 const CAPTURING_SCREENSHOT_TIMEOUT = 30000;
 const CAPTURING_SCREENSHOT_RETRY_BACKOFF = 500;
@@ -248,7 +249,7 @@ function createChromeTarget(
     )}&selectedStory=${encodeURIComponent(story)}`;
 
   const launchStoriesTab = withTimeout(LOADING_STORIES_TIMEOUT)(
-    withRetries(2)(async url => {
+    withRetries(5, RETRY_LOADING_STORIES_TIMEOUT)(async url => {
       const tab = await launchNewTab({
         width: 100,
         height: 100,


### PR DESCRIPTION
This fixes a common failure when doing `loki` on CircleCI. 

Over 100 runs:
* 100 times would fail the first time (caught by the `withRetries(2`)
* 90 times would work the second time
* 10 times it would fail the second time

This tries to fix 10% of the cases. 

Over the last 2 weeks we have been testing this patch (> 200 builds) and have had ZERO failures! 