### PR TITLE
don't clear error logs.

### DIFF
--- a/packages/target-chrome-docker/src/create-chrome-docker-target.js
+++ b/packages/target-chrome-docker/src/create-chrome-docker-target.js
@@ -128,9 +128,6 @@ function createChromeDockerTarget({
       logs.stderr.on('data', chunk => {
         errorLogs.push(chunk);
       });
-      logs.stderr.on('end', () => {
-        errorLogs = null;
-      });
 
       host = await getNetworkHost(execute, dockerId);
       try {

--- a/packages/target-chrome-docker/src/create-chrome-docker-target.js
+++ b/packages/target-chrome-docker/src/create-chrome-docker-target.js
@@ -124,7 +124,7 @@ function createChromeDockerTarget({
     if (code === 0) {
       dockerId = stdout;
       const logs = execute(dockerPath, ['logs', dockerId, '--follow']);
-      let errorLogs = [];
+      const errorLogs = [];
       logs.stderr.on('data', chunk => {
         errorLogs.push(chunk);
       });


### PR DESCRIPTION
When there's an error starting Chrome I get:
`FAIL chrome.docker/START: Cannot read property 'length' of null`
instead of the actual error message.

Not sure if there was a reason to set errorMessages to null, but this fixes the problem.