### PR TITLE
Add loki command alias to entry package

### DIFF
--- a/packages/loki/bin/loki
+++ b/packages/loki/bin/loki
@@ -1,0 +1,3 @@
+#!/usr/bin/env node
+
+require('@loki/runner/src/cli')();

--- a/packages/loki/package.json
+++ b/packages/loki/package.json
@@ -2,6 +2,9 @@
   "name": "loki",
   "version": "0.20.1",
   "description": "Visual Regression Testing for react-storybook",
+  "bin": {
+    "loki": "bin/loki"
+  },
   "keywords": [
     "storybook",
     "react-storybook",


### PR DESCRIPTION
With the monorepo restructuring the binary was moved to a subpackage, which seems to cause warnings/errors when installing globally as outlined in #221. 

This PR adds it back to the main `loki` package as an alias to the `runner` package. 