### PR TITLE
Edit react example to showcase loki.config.js usage

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ Example `package.json`:
 }
 ```
 
-You may also use a file named `.lokirc`, `.lokirc.json` or `loki.config.js` if you don't want to pollute your `package.json`.
+You may also use a file named `.lokirc`, `.lokirc.json` or `loki.config.js` (see the react example) if you don't want to pollute your `package.json`.
 
 ## `chromeSelector`
 

--- a/examples/react/loki.config.js
+++ b/examples/react/loki.config.js
@@ -1,0 +1,20 @@
+module.exports = {
+  "chromeSelector": ".wrapper > *, #root > *",
+  "diffingEngine": "looks-same",
+  "configurations": {
+    "chrome.laptop": {
+      "target": "chrome.docker",
+      "width": 1366,
+      "height": 768
+    },
+    "chrome.iphone7": {
+      "target": "chrome.docker",
+      "preset": "iPhone 7"
+    },
+    "chrome.a4": {
+      "target": "chrome.docker",
+      "preset": "A4 Paper"
+    }
+  },
+  "fetchFailIgnore": "localhost:1234/get"
+};

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -29,26 +29,6 @@
     "@storybook/react": "^5.3.13",
     "loki": "^0.20.3"
   },
-  "loki": {
-    "chromeSelector": ".wrapper > *, #root > *",
-    "diffingEngine": "looks-same",
-    "configurations": {
-      "chrome.laptop": {
-        "target": "chrome.docker",
-        "width": 1366,
-        "height": 768
-      },
-      "chrome.iphone7": {
-        "target": "chrome.docker",
-        "preset": "iPhone 7"
-      },
-      "chrome.a4": {
-        "target": "chrome.docker",
-        "preset": "A4 Paper"
-      }
-    },
-    "fetchFailIgnore": "localhost:1234/get"
-  },
   "eslintConfig": {
     "extends": "react-app"
   },


### PR DESCRIPTION
Moved the configuration for the React example to a separate file 'loki.config.js' in order to showcase the option of a separated config file