### PR TITLE
feat(website): add DocSearch as recommended by docusaurus

### DIFF
--- a/website/siteConfig.js
+++ b/website/siteConfig.js
@@ -18,6 +18,10 @@ const users = [
 ];
 
 const siteConfig = {
+  algolia: {
+    apiKey: '5a53968a2a72331b2f3cbffc75d92819',
+    indexName: 'loki'
+  },
   title: 'Loki', // Title for your website.
   tagline: 'Visual Regression Testing for Storybook',
   url: 'https://loki.js.org', // Your website URL


### PR DESCRIPTION
👋 team,

I am working on DocSearch. [We have an integration for Docusaurus](https://docusaurus.io/docs/en/search#enabling-the-search-bar). We thought it is a shame you can not also used this search that you can [find on reactjs for example](https://reactjs.org/).

This PR will add DocSearch to the documentation website. It will allow an user to have a learn-as-you-type experience by displaying results thanks to a dropdown in a live way.

Let me know if you need anything.