### PR TITLE
Listen to requests until selector is present

### DIFF
--- a/packages/browser/src/await-selector-present.js
+++ b/packages/browser/src/await-selector-present.js
@@ -1,0 +1,21 @@
+const awaitSelectorPresent = (window, selector, timeout = 10000) =>
+  new Promise((resolve, reject) => {
+    let resolutionTimer;
+    const rejectionTimer = setTimeout(() => {
+      clearTimeout(resolutionTimer);
+      reject(new Error(`Timeout after ${timeout}ms`));
+    }, timeout);
+
+    const waitForSelector = () => {
+      if (window.document.querySelector(selector)) {
+        clearTimeout(rejectionTimer);
+        resolve();
+      } else {
+        resolutionTimer = setTimeout(waitForSelector, 100);
+      }
+    };
+
+    waitForSelector();
+  });
+
+module.exports = awaitSelectorPresent;

--- a/packages/browser/src/index.js
+++ b/packages/browser/src/index.js
@@ -1,5 +1,6 @@
 const addLokiSessionMarker = require('./add-loki-session-marker');
 const awaitLokiReady = require('./await-loki-ready');
+const awaitSelectorPresent = require('./await-selector-present');
 const createStorybookConfigurator = require('./configure-storybook');
 const disableAnimations = require('./disable-animations');
 const disableInputCaret = require('./disable-input-caret');
@@ -10,6 +11,7 @@ const getStories = require('./get-stories');
 module.exports = {
   addLokiSessionMarker,
   awaitLokiReady,
+  awaitSelectorPresent,
   createStorybookConfigurator,
   disableAnimations,
   disableInputCaret,


### PR DESCRIPTION
For very large bundles/slow components, the rendering of the component can take a long while and since fonts are loaded first when they are needed to render some text, the current request stabilisation strategy doesn't work. 

This PR changes the behaviour to listen to requests to finish until the element we want to screenshot is present. 