### PR TITLE
Fix loki global check for React Native

### DIFF
--- a/packages/integration-react-native/src/configure-storybook-react-native.js
+++ b/packages/integration-react-native/src/configure-storybook-react-native.js
@@ -123,7 +123,7 @@ async function configureStorybook() {
   };
 
   const prepare = () => {
-    if ('loki' in global) {
+    if (!'loki' in global) {
       global.loki = {};
     }
     global.loki.isRunning = true;


### PR DESCRIPTION
It appears that the `global.loki` check added in #246 is incorrect and should instead be trying to create the `global.loki` only if it's not already defined.

This is currently causing a error preventing React Native tests from running at all as the line immediately after the if statement will try and assign `global.loki.isRunning = true;` while `global.loki` is undefined.