### PR TITLE
Prevent lambda batches from exceeding payload limits

### DIFF
--- a/packages/renderer-aws-lambda/package.json
+++ b/packages/renderer-aws-lambda/package.json
@@ -28,7 +28,7 @@
     "docker-lambda": "^0.15.3"
   },
   "peerDependencies": {
-    "chrome-aws-lambda": "^2.0.1"
+    "chrome-aws-lambda": ">=2"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/runner/src/commands/test/compare-screenshot.js
+++ b/packages/runner/src/commands/test/compare-screenshot.js
@@ -1,16 +1,8 @@
 const fs = require('fs-extra');
 const path = require('path');
-const { slugify } = require('transliteration');
 const { ReferenceImageError } = require('@loki/core');
 const { getImageDiffer } = require('./get-image-differ');
-
-const SLUGIFY_OPTIONS = {
-  lowercase: false,
-  separator: '_',
-};
-
-const defaultFileNameFormatter = ({ configurationName, kind, story }) =>
-  slugify(`${configurationName} ${kind} ${story}`, SLUGIFY_OPTIONS);
+const { getOutputPaths } = require('./get-output-paths');
 
 async function compareScreenshot(
   screenshot,
@@ -20,12 +12,12 @@ async function compareScreenshot(
   kind,
   story
 ) {
-  const getBaseName = options.fileNameFormatter || defaultFileNameFormatter;
-  const basename = getBaseName({ configurationName, kind, story });
-  const filename = `${basename}.png`;
-  const outputPath = `${options.outputDir}/${filename}`;
-  const referencePath = `${options.referenceDir}/${filename}`;
-  const diffPath = `${options.differenceDir}/${filename}`;
+  const { outputPath, referencePath, diffPath } = getOutputPaths(
+    options,
+    configurationName,
+    kind,
+    story
+  );
   const referenceExists = await fs.pathExists(referencePath);
   const shouldUpdateReference =
     options.updateReference || (!options.requireReference && !referenceExists);

--- a/packages/runner/src/commands/test/create-baseline-limited-batch-builder.js
+++ b/packages/runner/src/commands/test/create-baseline-limited-batch-builder.js
@@ -1,0 +1,50 @@
+const fs = require('fs');
+const { getOutputPaths } = require('./get-output-paths');
+
+const LAMBDA_PAYLOAD_LIMIT = 6291556; // in bytes
+const BASE64_ENCODING_OVERHEAD = 4 / 3;
+const FILL_RATE = 0.9;
+const DEFAULT_SIZE_LIMIT =
+  FILL_RATE * (LAMBDA_PAYLOAD_LIMIT / BASE64_ENCODING_OVERHEAD);
+
+const createBaselineLimitedBatchBuilder = (
+  options,
+  baselineSizeLimit = DEFAULT_SIZE_LIMIT
+) => (tasks, batchSize) => {
+  let currentBatch = [];
+  let accumulatedBatchSize = 0;
+  let lastFileSize = 200 * 1024;
+  const batches = [currentBatch];
+  for (let i = 0; i < tasks.length; i++) {
+    const task = tasks[i];
+    const { referencePath } = getOutputPaths(
+      options,
+      task.task.configurationName,
+      task.task.kind,
+      task.task.story
+    );
+    let size;
+    try {
+      const stat = fs.statSync(referencePath);
+      // eslint-disable-next-line prefer-destructuring
+      size = stat.size;
+      lastFileSize = size;
+    } catch (e) {
+      size = lastFileSize;
+    }
+    if (
+      currentBatch.length >= batchSize ||
+      (accumulatedBatchSize + size > baselineSizeLimit &&
+        currentBatch.length !== 0)
+    ) {
+      currentBatch = [];
+      accumulatedBatchSize = 0;
+      batches.push(currentBatch);
+    }
+    currentBatch.push(task);
+    accumulatedBatchSize += size;
+  }
+  return batches;
+};
+
+module.exports = createBaselineLimitedBatchBuilder;

--- a/packages/runner/src/commands/test/create-baseline-limited-batch-builder.spec.js
+++ b/packages/runner/src/commands/test/create-baseline-limited-batch-builder.spec.js
@@ -1,0 +1,92 @@
+const fs = require('fs');
+const createBaselineLimitedBatchBuilder = require('./create-baseline-limited-batch-builder');
+const { getOutputPaths } = require('./get-output-paths');
+
+jest.mock('fs');
+
+const mockOptions = { referenceDir: '/references' };
+
+const mockFsWithTasks = mockTasks => {
+  const files = mockTasks.reduce((acc, task) => {
+    const { referencePath } = getOutputPaths(
+      mockOptions,
+      task.task.configurationName,
+      task.task.kind,
+      task.task.story
+    );
+    acc[referencePath] = task.size;
+    return acc;
+  }, {});
+  fs.statSync.mockImplementation(file => {
+    if (file in files) {
+      return {
+        size: files[file],
+      };
+    }
+    throw new Error('File not found');
+  });
+};
+
+const generateTasks = sizes =>
+  sizes.map((size, i) => ({
+    size,
+    task: {
+      configurationName: 'configuration',
+      kind: 'kind',
+      story: `story ${i + 1}`,
+    },
+  }));
+
+const expectBatchLengths = ({ options, limit, tasks, batchSize }) => {
+  return expect(
+    createBaselineLimitedBatchBuilder(options, limit)(tasks, batchSize).map(
+      batch => batch.length
+    )
+  );
+};
+
+describe('createBaselineLimitedBatchBuilder', () => {
+  const options = mockOptions;
+  const batchSize = 5;
+
+  it('limits batch size by reference file size', () => {
+    const limit = 10;
+    const tasks = generateTasks(new Array(10).fill(limit / 2));
+    mockFsWithTasks(tasks);
+    expectBatchLengths({ options, limit, tasks, batchSize }).toEqual([
+      2,
+      2,
+      2,
+      2,
+      2,
+    ]);
+  });
+
+  it('falls back to batchSize if limit is not reached', () => {
+    const limit = 10;
+    const tasks = generateTasks(new Array(10).fill(limit / 20));
+    mockFsWithTasks(tasks);
+    expectBatchLengths({ options, limit, tasks, batchSize }).toEqual([5, 5]);
+  });
+
+  it('assumes last known file size if reference is missing', () => {
+    const limit = 10;
+    const tasks = generateTasks([1, 2, 3, 11, 11, 11, 11, 11, 11, 11]);
+    mockFsWithTasks(tasks.slice(0, 3));
+    expectBatchLengths({ options, limit, tasks, batchSize }).toEqual([4, 3, 3]);
+  });
+
+  it('allows files over the limit', () => {
+    const limit = 10;
+    const tasks = generateTasks([1, 2, 3, 4, 5, 5, 4, 7, 8, 11]);
+    mockFsWithTasks(tasks);
+    expectBatchLengths({ options, limit, tasks, batchSize }).toEqual([
+      4,
+      2,
+      1,
+      1,
+      1,
+      1,
+    ]);
+  });
+});

--- a/packages/runner/src/commands/test/get-output-paths.js
+++ b/packages/runner/src/commands/test/get-output-paths.js
@@ -1,0 +1,22 @@
+const { slugify } = require('transliteration');
+
+const SLUGIFY_OPTIONS = {
+  lowercase: false,
+  separator: '_',
+};
+
+const defaultFileNameFormatter = ({ configurationName, kind, story }) =>
+  slugify(`${configurationName} ${kind} ${story}`, SLUGIFY_OPTIONS);
+
+function getOutputPaths(options, configurationName, kind, story) {
+  const getBaseName = options.fileNameFormatter || defaultFileNameFormatter;
+  const basename = getBaseName({ configurationName, kind, story });
+  const filename = `${basename}.png`;
+  const outputPath = `${options.outputDir}/${filename}`;
+  const referencePath = `${options.referenceDir}/${filename}`;
+  const diffPath = `${options.differenceDir}/${filename}`;
+
+  return { outputPath, referencePath, diffPath };
+}
+
+module.exports = { defaultFileNameFormatter, getOutputPaths };

--- a/packages/runner/src/commands/test/run-tests.js
+++ b/packages/runner/src/commands/test/run-tests.js
@@ -18,6 +18,7 @@ const {
   createAndroidEmulatorTarget,
 } = require('@loki/target-native-android-emulator');
 const { die } = require('../../console');
+const createBaselineLimitedBatchBuilder = require('./create-baseline-limited-batch-builder');
 const testBatch = require('./test-batch');
 const { TaskRunner } = require('./task-runner');
 const {
@@ -73,7 +74,8 @@ async function runTests(flatConfigurations, options) {
     configurations,
     concurrency = 1,
     tolerance = 0,
-    batchSize = 1
+    batchSize = 1,
+    batchBuilder
   ) => {
     let storybook;
 
@@ -174,6 +176,7 @@ async function runTests(flatConfigurations, options) {
                   concurrency: Math.ceil(concurrency / batchSize),
                   exitOnError: false,
                   batchSize,
+                  batchBuilder,
                   batchExector: batch =>
                     testBatch(
                       target,
@@ -228,7 +231,8 @@ async function runTests(flatConfigurations, options) {
           configurations,
           options.chromeConcurrency,
           options.chromeTolerance,
-          options.chromeAwsLambdaBatchSize
+          options.chromeAwsLambdaBatchSize,
+          createBaselineLimitedBatchBuilder(options)
         );
       }
       case 'chrome.docker': {


### PR DESCRIPTION
Sometimes stories with very large images can cause the lambda payload limits to be exceeded when batched together. Instead of lowering the size of all batches which would make execution slightly slower and more expensive, this PR makes an estimation of how many stories can fit into a batch based on the size of existing baselines. 