### PR TITLE
Fix lokiAsync regression

### DIFF
--- a/examples/react/.storybook/preview.js
+++ b/examples/react/.storybook/preview.js
@@ -1,0 +1,1 @@
+import 'loki/configure-react';

--- a/examples/react/src/stories/index.stories.js
+++ b/examples/react/src/stories/index.stories.js
@@ -20,13 +20,11 @@ import Hover from '../Hover';
 import FocusedInput from '../FocusedInput';
 import IsLokiRunning, { withDisabledAnimations } from '../IsLokiRunning';
 
-storiesOf('Welcome', module).add(
-  'to Storybook',
-  () => <Welcome showApp={linkTo('Button')} />,
-  {
+storiesOf('Welcome', module)
+  .lokiSkip('to Storybook', () => <Welcome showApp={linkTo('Button')} />)
+  .add('skipped', () => <Welcome showApp={linkTo('Button')} />, {
     loki: { skip: true },
-  }
-);
+  });
 
 storiesOf('Text', module).add('with external font', () => (
   <CursiveText>Hello CursiveText</CursiveText>
@@ -35,6 +33,9 @@ storiesOf('Text', module).add('with external font', () => (
 storiesOf('Asynchronous render', module)
   .add('Logo without delay', () => <Logo />)
   .add('Logo with 1s delay', () => <Logo delay={1000} />)
+  .lokiAsync('lokiAsync() with 1s delay', ({ done }) => (
+    <DelayedComponent delay={1000} onDone={done} />
+  ))
   .add('createAsyncCallback() with 1s delay', () => (
     <DelayedComponent delay={1000} onDone={createAsyncCallback()} />
   ));

--- a/packages/browser/src/configure-storybook.js
+++ b/packages/browser/src/configure-storybook.js
@@ -8,11 +8,9 @@ const populateLokiHelpers = require('./populate-loki-helpers');
 function createConfigurator(storybook) {
   return function configureStorybook() {
     if (typeof window === 'object') {
-      const readyStateManager = createReadyStateManager();
-      populateLokiHelpers(window, {
-        getStorybook: decorateStorybook(storybook),
-      });
-      populateLokiHelpers(window, readyStateManager);
+      populateLokiHelpers(window, createReadyStateManager());
+      const getStorybook = decorateStorybook(storybook, window.loki); // Pass window.loki as most likely a different readyStateManager has already been assigned making the previous statement a no-op
+      populateLokiHelpers(window, { getStorybook });
     }
   };
 }


### PR DESCRIPTION
#261 caused a regression for stories using `lokiAsync` that would cause it to time out, due to two instances of the ready state manager. 

I want to remove these eventually, but let's unbreak it for now.