### PR TITLE
Fix graphicsMagick comparing images with different dimensions. Fixes #44

### DIFF
--- a/packages/diff-graphics-magick/package.json
+++ b/packages/diff-graphics-magick/package.json
@@ -21,8 +21,7 @@
   "main": "src/index.js",
   "dependencies": {
     "fs-extra": "^8.1.0",
-    "gm": "^1.23.1",
-    "image-size": "^0.9.1"
+    "gm": "^1.23.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/diff-graphics-magick/package.json
+++ b/packages/diff-graphics-magick/package.json
@@ -21,7 +21,8 @@
   "main": "src/index.js",
   "dependencies": {
     "fs-extra": "^8.1.0",
-    "gm": "^1.23.1"
+    "gm": "^1.23.1",
+    "image-size": "^0.9.1"
   },
   "publishConfig": {
     "access": "public"

--- a/packages/diff-graphics-magick/src/create-graphics-magick-differ.js
+++ b/packages/diff-graphics-magick/src/create-graphics-magick-differ.js
@@ -1,9 +1,21 @@
 const fs = require('fs-extra');
 const gm = require('gm');
+const imageSize = require('image-size');
 
 function createGraphicsMagickDiffer(config) {
   return function getImageDiff(path1, path2, diffPath, tolerance) {
     const instanceConfig = { tolerance: tolerance / 100, ...config };
+
+    const path1Dimensions = imageSize(path1);
+    const path2Dimensions = imageSize(path2);
+
+    if (
+      path1Dimensions.height !== path2Dimensions.height ||
+      path1Dimensions.width !== path2Dimensions.width
+    ) {
+      return Promise.resolve(false);
+    }
+
     return new Promise((resolve, reject) => {
       gm.compare(
         path1,

--- a/packages/diff-graphics-magick/src/create-graphics-magick-differ.js
+++ b/packages/diff-graphics-magick/src/create-graphics-magick-differ.js
@@ -1,42 +1,56 @@
 const fs = require('fs-extra');
 const gm = require('gm');
-const imageSize = require('image-size');
+
+const getSize = (filePath) =>
+  new Promise((resolve, reject) => {
+    gm(filePath).size((err, value) => {
+      if (err) {
+        return reject(err);
+      }
+
+      return resolve(value);
+    });
+  });
+
+const compare = (path1, path2, instanceConfig, diffPath) =>
+  new Promise((resolve, reject) => {
+    gm.compare(
+      path1,
+      path2,
+      { ...instanceConfig, file: diffPath },
+      (err, isEqual) => {
+        if (err) {
+          if (typeof err === 'string') {
+            reject(new Error(err));
+          } else {
+            reject(err);
+          }
+        } else {
+          if (isEqual) {
+            fs.remove(diffPath);
+          }
+          resolve(isEqual);
+        }
+      }
+    );
+  });
 
 function createGraphicsMagickDiffer(config) {
   return function getImageDiff(path1, path2, diffPath, tolerance) {
     const instanceConfig = { tolerance: tolerance / 100, ...config };
 
-    const path1Dimensions = imageSize(path1);
-    const path2Dimensions = imageSize(path2);
-
-    if (
-      path1Dimensions.height !== path2Dimensions.height ||
-      path1Dimensions.width !== path2Dimensions.width
-    ) {
-      return Promise.resolve(false);
-    }
-
-    return new Promise((resolve, reject) => {
-      gm.compare(
-        path1,
-        path2,
-        { ...instanceConfig, file: diffPath },
-        (err, isEqual) => {
-          if (err) {
-            if (typeof err === 'string') {
-              reject(new Error(err));
-            } else {
-              reject(err);
-            }
-          } else {
-            if (isEqual) {
-              fs.remove(diffPath);
-            }
-            resolve(isEqual);
-          }
+    return Promise.all([getSize(path1), getSize(path2)]).then(
+      ([path1Dimensions, path2Dimensions]) => {
+        if (
+          path1Dimensions.height !== path2Dimensions.height ||
+          path1Dimensions.width !== path2Dimensions.width
+        ) {
+          return false;
         }
-      );
-    });
+
+        return compare(path1, path2, instanceConfig, diffPath);
+      }
+    );
   };
 }
 


### PR DESCRIPTION
## PRE

Here is no contributing guide, so I don't know how to format Pull Request, which steps I need to do to check my changes and I don't know how to test this changes properly.

## Problem

GraphicsMagick's compare method checks only pixel diff in first image dimensions. This means that if second image is first image concated with another image, GM will decide that the images are equal.

In practice it means, that than I, as programmer, add some content to existing component/story, GM will not report any diff and Loki.js tests will pass. 

## Resolution

Check images dimensions manually. That method I use in current job project and it works.