### PR TITLE
Allow slashes in diff paths with looks-same

### DIFF
--- a/packages/diff-looks-same/src/create-looks-same-differ.js
+++ b/packages/diff-looks-same/src/create-looks-same-differ.js
@@ -20,12 +20,13 @@ function createLooksSameDiffer(config) {
         return reject(new Error('Current image is empty'));
       }
 
-      return looksSame(reference, current, instanceConfig, (err, isSame) => {
+      return looksSame(reference, current, instanceConfig, async (err, isSame) => {
         if (err) {
           reject(err);
         } else if (isSame) {
           resolve(isSame);
         } else {
+          await fs.ensureFile(diffPath);
           looksSame.createDiff(
             {
               ...instanceConfig,

--- a/packages/diff-looks-same/src/create-looks-same-differ.js
+++ b/packages/diff-looks-same/src/create-looks-same-differ.js
@@ -20,13 +20,13 @@ function createLooksSameDiffer(config) {
         return reject(new Error('Current image is empty'));
       }
 
-      return looksSame(reference, current, instanceConfig, async (err, isSame) => {
+      return looksSame(reference, current, instanceConfig, (err, isSame) => {
         if (err) {
           reject(err);
         } else if (isSame) {
           resolve(isSame);
         } else {
-          await fs.ensureFile(diffPath);
+          fs.ensureFileSync(diffPath);
           looksSame.createDiff(
             {
               ...instanceConfig,

--- a/packages/diff-looks-same/src/create-looks-same-differ.spec.js
+++ b/packages/diff-looks-same/src/create-looks-same-differ.spec.js
@@ -1,0 +1,51 @@
+const fs = require('fs-extra');
+const path = require('path');
+const createLooksSameDiffer = require('./create-looks-same-differ');
+
+const workingDirectory = './fwtaajxnfeuzedzu';
+const darkGrayPath = path.join(workingDirectory, 'dark-dray.png');
+const lightGrayPath = path.join(workingDirectory, 'light-dray.png');
+
+function writeBase64Image({ outputPath, base64String }) {
+  const imageData = base64String.split(';base64,').pop();
+
+  fs.ensureFileSync(outputPath);
+  fs.writeFileSync(outputPath, imageData, { encoding: 'base64' });
+}
+
+describe('createLooksSameDiffer', () => {
+  beforeEach(() => {
+    const darkGrayBase64String =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQYV2NISUn5DwAEiAIshLJN6AAAAABJRU5ErkJggg==';
+    writeBase64Image({
+      outputPath: darkGrayPath,
+      base64String: darkGrayBase64String,
+    });
+    const lightGrayBase64String =
+      'data:image/png;base64,iVBORw0KGgoAAAANSUhEUgAAAAEAAAABCAYAAAAfFcSJAAAADUlEQVQYV2M4ceLEfwAIDANYMDoQswAAAABJRU5ErkJggg==';
+    writeBase64Image({
+      outputPath: lightGrayPath,
+      base64String: lightGrayBase64String,
+    });
+  });
+
+  afterEach(() => {
+    fs.rmdirSync(workingDirectory, { recursive: true });
+  });
+
+  it('creates diff files in deeply nested directories', async () => {
+    const config = {};
+    const looksSameDiffer = createLooksSameDiffer(config);
+
+    const diffPath = path.join(
+      workingDirectory,
+      'deeply',
+      'nested',
+      'diff.png'
+    );
+    const tolerance = 0;
+    await looksSameDiffer(darkGrayPath, lightGrayPath, diffPath, tolerance);
+
+    expect(fs.existsSync(diffPath)).toEqual(true);
+  });
+});


### PR DESCRIPTION
This PR is a partial fix for https://github.com/oblador/loki/issues/229. It creates the output diff folder immediately before asking looks-same to create a diff file. Because it only creates the folder when a diff file is going to be created, it does not create any empty folders.

This patch only applies to the looks-same differ. The Graphics Magic differ creates diff files even when there are no differences, so it needs to be fixed in a different way.