### PR TITLE
Surface render errors to user

### DIFF
--- a/packages/browser/src/get-storybook-error.js
+++ b/packages/browser/src/get-storybook-error.js
@@ -1,0 +1,11 @@
+const getStorybookError = window => {
+  const errorElement = window.document.querySelector(
+    '.sb-show-errordisplay #error-message'
+  );
+  if (errorElement) {
+    return errorElement.innerText;
+  }
+  return null;
+};
+
+module.exports = getStorybookError;

--- a/packages/browser/src/index.js
+++ b/packages/browser/src/index.js
@@ -5,6 +5,7 @@ const disableAnimations = require('./disable-animations');
 const disableInputCaret = require('./disable-input-caret');
 const disablePointerEvents = require('./disable-pointer-events');
 const getSelectorBoxSize = require('./get-selector-box-size');
+const getStorybookError = require('./get-storybook-error');
 const getStories = require('./get-stories');
 const populateLokiHelpers = require('./populate-loki-helpers');
 const setLokiIsRunning = require('./set-loki-is-running');
@@ -18,6 +19,7 @@ module.exports = {
   disableInputCaret,
   disablePointerEvents,
   getSelectorBoxSize,
+  getStorybookError,
   getStories,
   populateLokiHelpers,
   setLokiIsRunning,


### PR DESCRIPTION
Currently loki will fail either by not returning any stories or by saying timed out waiting for selector when in fact the story is throwing a render error. This can be a bit confusing if running in CI or not working in storybook while running the tests. This PR will present the render error from storybook to the user instead. 