### PR TITLE
Add silent flag

### DIFF
--- a/docs/command-line-arguments.md
+++ b/docs/command-line-arguments.md
@@ -45,6 +45,7 @@ yarn loki test -- --port 9009
 | **`--targetFilter`**                    | Regular expression for targets that should be tested.                                                                                           | _None_                                          |
 | **`--requireReference`**                | Fail stories without reference image, useful for CI.                                                                                            | _False, true for CI_                            |
 | **`--verboseRenderer`**                 | Plain text renderer, useful for CI.                                                                                                             | _False, true for CI_                            |
+| **`--silent`**                          | Plain text renderer that will only output errors.                                                                                               | `false`                                         |
 | **`--dockerWithSudo`**                  | Run docker commands with sudo.                                                                                                                  | `false`                                         |
 
 ## `loki update`

--- a/packages/runner/src/cli.js
+++ b/packages/runner/src/cli.js
@@ -35,7 +35,9 @@ async function run() {
   const command = argv._[0] || 'test';
   const executor = getExecutorForCommand(command);
 
-  bold(`loki ${command} v${version}`);
+  if (!argv.silent) {
+    bold(`loki ${command} v${version}`);
+  }
 
   try {
     await executor(args);

--- a/packages/runner/src/commands/test/parse-options.js
+++ b/packages/runner/src/commands/test/parse-options.js
@@ -49,6 +49,7 @@ function parseOptions(args, config) {
     'looks-same': $('looks-same'),
     gm: $('gm'),
     verboseRenderer: $('verboseRenderer'),
+    silent: $('silent'),
     requireReference: $('requireReference') || ciInfo.isCI,
     updateReference: argv._[0] === 'update',
     targetFilter: argv.targetFilter,

--- a/packages/runner/src/commands/test/renderers/index.js
+++ b/packages/runner/src/commands/test/renderers/index.js
@@ -1,7 +1,13 @@
 const importJsx = require('import-jsx');
 const { renderVerbose } = require('./verbose');
 const { renderNonInteractive } = require('./non-interactive');
+const { renderSilent } = require('./silent');
 
 const { renderInteractive } = importJsx('./interactive');
 
-module.exports = { renderInteractive, renderVerbose, renderNonInteractive };
+module.exports = {
+  renderInteractive,
+  renderVerbose,
+  renderSilent,
+  renderNonInteractive,
+};

--- a/packages/runner/src/commands/test/renderers/non-interactive.js
+++ b/packages/runner/src/commands/test/renderers/non-interactive.js
@@ -10,15 +10,24 @@ const { renderTask } = require('./render-task');
 
 const renderNonInteractive = taskRunner => {
   const handleChange = task => {
-    if (
-      (task.status === STATUS_FAILED || task.status === STATUS_SUCCEEDED) &&
-      task.meta.type !== TASK_TYPE_TESTS &&
-      task.meta.type !== TASK_TYPE_TARGET
-    ) {
-      console.error(renderTask(task));
-      if (task.error && task.error.instructions) {
-        console.info(task.error.instructions);
-      }
+    const message = renderTask(task);
+    // eslint-disable-next-line default-case
+    switch (task.status) {
+      case STATUS_FAILED:
+        console.error(message);
+        if (task.error && task.error.instructions) {
+          console.info(task.error.instructions);
+        }
+        break;
+
+      case STATUS_SUCCEEDED:
+        if (
+          task.meta.type !== TASK_TYPE_TESTS &&
+          task.meta.type !== TASK_TYPE_TARGET
+        ) {
+          console.log(message);
+        }
+        break;
     }
   };
   taskRunner.on(EVENT_CHANGE, handleChange);

--- a/packages/runner/src/commands/test/renderers/silent.js
+++ b/packages/runner/src/commands/test/renderers/silent.js
@@ -1,0 +1,26 @@
+/* eslint-disable no-console */
+
+const { EVENT_CHANGE, STATUS_FAILED } = require('../task-runner');
+const { TASK_TYPE_TESTS, TASK_TYPE_TARGET } = require('../constants');
+const { renderTask } = require('./render-task');
+
+const renderSilent = taskRunner => {
+  const handleChange = task => {
+    if (
+      task.status === STATUS_FAILED &&
+      task.meta.type !== TASK_TYPE_TESTS &&
+      task.meta.type !== TASK_TYPE_TARGET
+    ) {
+      console.error(renderTask(task));
+      if (task.error && task.error.instructions) {
+        console.info(task.error.instructions);
+      }
+    }
+  };
+  taskRunner.on(EVENT_CHANGE, handleChange);
+  const stopRendering = () =>
+    taskRunner.removeListener(EVENT_CHANGE, handleChange);
+  return stopRendering;
+};
+
+module.exports = { renderSilent };

--- a/packages/runner/src/commands/test/run-tests.js
+++ b/packages/runner/src/commands/test/run-tests.js
@@ -25,6 +25,7 @@ const {
   renderInteractive,
   renderVerbose,
   renderNonInteractive,
+  renderSilent,
 } = require('./renderers');
 const {
   TASK_TYPE_TARGET,
@@ -36,7 +37,18 @@ const {
   TASK_TYPE_STOP,
 } = require('./constants');
 
-const defaultRenderer = ciInfo.isCI ? renderNonInteractive : renderInteractive;
+const getRendererForOptions = options => {
+  if (options.silent) {
+    return renderSilent;
+  }
+  if (options.verboseRenderer) {
+    return renderVerbose;
+  }
+  if (ciInfo.isCI) {
+    return renderNonInteractive;
+  }
+  return renderInteractive;
+};
 
 async function placeGitignore(pathsToIgnore) {
   const parentDir = path.dirname(pathsToIgnore[0]);
@@ -276,7 +288,7 @@ async function runTests(flatConfigurations, options) {
   );
 
   const context = { activeTargets: [] };
-  const render = options.verboseRenderer ? renderVerbose : defaultRenderer;
+  const render = getRendererForOptions(options);
   const stopRendering = render(tasks);
 
   try {


### PR DESCRIPTION
For large test suites the default non-interactive logger can be quite noisy and making it hard to find the actual error. To solve these cases, this PR adds a `--silent` flag that will only output error messages. 