### PR TITLE
add storybook 6 in peerDependencies list

### DIFF
--- a/packages/integration-react/package.json
+++ b/packages/integration-react/package.json
@@ -23,7 +23,7 @@
     "@loki/browser": "^0.27.0"
   },
   "peerDependencies": {
-    "@storybook/react": "^5"
+    "@storybook/react": "^5 || ^6"
   },
   "peerDependenciesMeta": {
     "@storybook/react": {

--- a/packages/loki/package.json
+++ b/packages/loki/package.json
@@ -41,6 +41,14 @@
     "@loki/target-native-android-emulator": "^0.27.0",
     "@loki/target-native-ios-simulator": "^0.27.0"
   },
+  "peerDependencies": {
+    "@storybook/react": "^5 || ^6"
+  },
+  "peerDependenciesMeta": {
+    "@storybook/react": {
+      "optional": true
+    }
+  },
   "publishConfig": {
     "access": "public"
   }


### PR DESCRIPTION
Tested with storybook 6 and it's working great.

Adding storybook 6 in our peerDependencies list.

also `loki` claims `@loki/integration-react` as its dependencies, we would have to decalre optional peerDepndnecies for `loki` as well.