### PR TITLE
Adapt missing code to exitCode extraction after execa version bump

### DIFF
--- a/packages/target-chrome-docker/src/get-network-host.js
+++ b/packages/target-chrome-docker/src/get-network-host.js
@@ -11,14 +11,14 @@ const getNetworkHost = async (execute, dockerId) => {
   // If we are running inside a docker container, our spawned docker chrome instance will be a sibling on the default
   // bridge, which means we can talk directly to it via its IP address.
   if (runningInsideDocker) {
-    const { code, stdout } = await execute('docker', [
+    const { exitCode, stdout } = await execute('docker', [
       'inspect',
       '-f',
       '{{range .NetworkSettings.Networks}}{{.IPAddress}}{{end}}',
       dockerId,
     ]);
 
-    if (code !== 0) {
+    if (exitCode !== 0) {
       throw new Error('Unable to determine IP of docker container');
     }
 


### PR DESCRIPTION
In 5ab26d6a5ea5bba33f31ff7f20f05c60b0d37b13 you bumped the version of execa from 1.0.0 to 5.0.0 and also updated the extraction from `code` to `exitCode` but you missed one place :)