### PR TITLE
Feature/diff with reference

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -58,6 +58,10 @@ There are three currently available options to choose from when comparing images
 }
 ```
 
+### `includeReferenceOnDiff`
+
+This property enables combining the diff with the reference images, side by side. This allows for a better visualization of the previous state and the new one, along with the diff engine result.
+
 ### [`pixelmatch`](https://github.com/mapbox/pixelmatch)
 
 The default engine and is JavaScript only. It's more sensitive to changes on large images and is less susceptible to anti alias flakiness.

--- a/packages/runner/src/commands/test/compare-screenshot.js
+++ b/packages/runner/src/commands/test/compare-screenshot.js
@@ -37,7 +37,8 @@ async function compareScreenshot(
 
   const isEqual = await getImageDiffer(
     options.diffingEngine,
-    options[options.diffingEngine]
+    options[options.diffingEngine],
+    options.includeReferenceOnDiff
   )(referencePath, outputPath, diffPath, tolerance);
 
   if (!isEqual) {

--- a/packages/runner/src/commands/test/get-image-differ.js
+++ b/packages/runner/src/commands/test/get-image-differ.js
@@ -2,11 +2,11 @@ const { createGraphicsMagickDiffer } = require('@loki/diff-graphics-magick');
 const { createLooksSameDiffer } = require('@loki/diff-looks-same');
 const { createPixelmatchDiffer } = require('@loki/diff-pixelmatch');
 
-function getImageDiffer(engine, config) {
+function getImageDiffer(engine, config, includeReferenceOnDiff) {
   switch (engine) {
     case undefined:
     case 'pixelmatch': {
-      return createPixelmatchDiffer(config);
+      return createPixelmatchDiffer(config, includeReferenceOnDiff);
     }
     case 'looks-same': {
       return createLooksSameDiffer(config);

--- a/packages/runner/src/commands/test/parse-options.js
+++ b/packages/runner/src/commands/test/parse-options.js
@@ -44,6 +44,7 @@ function parseOptions(args, config) {
     skipStoriesPattern: $('skipStories'),
     storiesFilter: $('storiesFilter'),
     diffingEngine: $('diffingEngine') || 'pixelmatch',
+    includeReferenceOnDiff: $('includeReferenceOnDiff'),
     fetchFailIgnore: $('fetchFailIgnore'),
     'looks-same': $('looks-same'),
     gm: $('gm'),


### PR DESCRIPTION
This PR enables a feature requested by #144 as it's useful for when comparing complex UI changes.

## What does it change:
- Added a new property called includeReferenceOnDiff (default: **false**)
- When the property is enabled, the reference image and the current images are concatenated side by side along with the diff result.

## Currently is set as draft because it needs the following adjustments:
### Make the property work on the other two diff engines, **if someone want to do it, fell free to contribute to this PR as well**