### PR TITLE
Add configurationFilter per story by parameters

### DIFF
--- a/packages/runner/src/commands/test/test-batch.js
+++ b/packages/runner/src/commands/test/test-batch.js
@@ -34,31 +34,42 @@ function testBatch(target, batch, options, tolerance) {
       .catch((error) => resolvers.forEach(([, reject]) => reject(error)));
     return promises;
   }
-  return batch.map(
-    async ({
-      configuration,
-      configurationName,
-      id,
-      kind,
-      story,
-      parameters,
-    }) => {
-      const screenshot = await target.captureScreenshotForStory(
-        id,
-        options,
+  return batch
+    .filter(({ configurationName, parameters }) => {
+      if (parameters.configurationFilter) {
+        const testConfiguration = new RegExp(parameters.configurationFilter);
+
+        if (!testConfiguration.test(configurationName)) {
+          return false;
+        }
+      }
+      return true;
+    })
+    .map(
+      async ({
         configuration,
-        parameters
-      );
-      return compareScreenshot(
-        screenshot,
-        options,
-        tolerance,
         configurationName,
+        id,
         kind,
-        story
-      );
-    }
-  );
+        story,
+        parameters,
+      }) => {
+        const screenshot = await target.captureScreenshotForStory(
+          id,
+          options,
+          configuration,
+          parameters
+        );
+        return compareScreenshot(
+          screenshot,
+          options,
+          tolerance,
+          configurationName,
+          kind,
+          story
+        );
+      }
+    );
 }
 
 module.exports = testBatch;


### PR DESCRIPTION
This [issue](https://github.com/oblador/loki/issues/280) can be fixed by filter stories which doesn't match configurationFilter parameter defined in story:
```
Default.parameters = {
	loki: {
		configurationFilter: 'desktop' // regex string
	}
};
```

let me know if it is ok for you and where to put story parameters docs. Any tests for this feature needed?

Thx
CD