### PR TITLE
fix: compare with new correct error message from waitOn

### DIFF
--- a/packages/target-chrome-docker/src/create-chrome-docker-target.js
+++ b/packages/target-chrome-docker/src/create-chrome-docker-target.js
@@ -163,7 +163,10 @@ function createChromeDockerTarget({
       try {
         await waitOnCDPAvailable(host, port);
       } catch (error) {
-        if (error.message === 'Timeout' && errorLogs.length !== 0) {
+        if (
+          error.message.startsWith('Timed out waiting for') &&
+          errorLogs.length !== 0
+        ) {
           throw new ChromeError(
             `Chrome failed to start with ${
               errorLogs.length === 1 ? 'error' : 'errors'


### PR DESCRIPTION
Since wait-on >= 5.2, the error message has been changed from `Timeout` to `Timed out waiting for`:
https://github.com/jeffbski/wait-on/blob/3f3bd9544fd320665eff1975f0ad0a059107471d/lib/wait-on.js#L25