### PR TITLE
Use Node.js 14 for CLI integration tests in GitHub Actions

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -50,7 +50,7 @@ jobs:
       - name: Use Node.js
         uses: actions/setup-node@v1
         with:
-          node-version: '12.x'
+          node-version: '14.x'
       - name: Install dependencies
         run: yarn --frozen-lockfile --non-interactive --silent --ignore-scripts
       - name: Run integration tests


### PR DESCRIPTION
## Summary

As requested in https://github.com/oblador/loki/pull/353#issuecomment-1001339392

- fixes https://github.com/oblador/loki/runs/4620140217
- unblocks https://github.com/oblador/loki/pull/352

## Problem

The last build failed ❌ because one of the dependencies doesn't support Node.js 12.x

🔗 https://github.com/oblador/loki/runs/4620140217
![image](https://user-images.githubusercontent.com/3720424/147433615-596e26b3-e366-4d52-a940-3d9f66f0bf53.png)