### PR TITLE
Story query params in configuration

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -113,7 +113,7 @@ module.exports = {
 ## `configurations`
 
 | Name                                 | Type      | Description                                                                                                                                               | Targets      |
-| ------------------------------------ | --------- | --------------------------------------------------------------------------------------------------------------------------------------------------------- | ------------ |
+| ------------------------------------ |-----------|-----------------------------------------------------------------------------------------------------------------------------------------------------------| ------------ |
 | **`target`**                         | _string_  | Target platform, possible values are `chrome.app`, `chrome.docker`, `chrome.aws-lambda`, `ios.simulator`, `android.emulator`.                             | All          |
 | **`skipStories`**                    | _string_  | **DEPRECATED** Same as `loki.skipStories`, but applied to only this configuration.                                                                        | All          |
 | **`storiesFilter`**                  | _string_  | Same as `loki.storiesFilter`, but applied to only this configuration.                                                                                     | All          |
@@ -126,3 +126,4 @@ module.exports = {
 | **`deviceScaleFactor`**              | _integer_ | Browser pixel density multiple, use `2` for retina, not supported in docker.                                                                              | `chrome.app` |
 | **`mobile`**                         | _boolean_ | Whether to emulate mobile device. This includes viewport meta tag, overlay scrollbars, text autosizing and more.                                          | `chrome.*`   |
 | **`media`**                          | _string_  | Emulates the given media for CSS media queries.                                                                                                           | _None_       |
+| **`storyQueryParams`**               | _object_  | Adds query params to story fetch URL. Example: `{theme: "dark"}`                                                                                          | _None_       |

--- a/packages/target-chrome-core/src/create-chrome-target.js
+++ b/packages/target-chrome-core/src/create-chrome-target.js
@@ -323,10 +323,15 @@ function createChromeTarget(
     return client;
   }
 
-  const getStoryUrl = (storyId) =>
-    `${resolvedBaseUrl}/iframe.html?id=${encodeURIComponent(
-      storyId
-    )}&viewMode=story`;
+  const getStoryUrl = (storyId, storyQueryParams = {}) => {
+    const params = new URLSearchParams({
+      id: storyId,
+      getStoryUrl: 'story',
+      ...storyQueryParams,
+    });
+
+    return `${resolvedBaseUrl}/iframe.html?${params.toString()}`;
+  };
 
   const launchStoriesTab = withTimeout(LOADING_STORIES_TIMEOUT)(
     withRetries(
@@ -388,7 +393,7 @@ function createChromeTarget(
       parameters.chromeSelector ||
       configuration.chromeSelector ||
       options.chromeSelector;
-    const url = getStoryUrl(storyId);
+    const url = getStoryUrl(storyId, configuration.storyQueryParams);
 
     const tab = await launchNewTab(tabOptions);
     let screenshot;


### PR DESCRIPTION
This feature allows you to configure stories more deeply. For example, we can support themes (https://storybook.js.org/addons/storybook-addon-themes). You just need to pass query param into configuration. 
Example: 
` "chrome.docker.dark": {
        "target": "chrome.docker",
        "width": 1980,
        "height": 1000,
        "looks-same": {
          "ignoreCaret": true
        },
        "storyQueryParams": {"theme": "dark"}
      },`
      
And then implement a simple script in `.storybook/preview-head.html` to convert query params to HTML tag class. 