### PR TITLE
Enable manual trigger event for website workflow

### DIFF
--- a/.github/workflows/website.yml
+++ b/.github/workflows/website.yml
@@ -1,6 +1,7 @@
 name: Website
 
 on:
+  workflow_dispatch:
   release:
     types: [created]
 


### PR DESCRIPTION
Publish the website to GitHub Pages when a new release is created or the workflow is manually triggered.

### References

- https://docs.github.com/en/actions/managing-workflow-runs/manually-running-a-workflow
- https://docs.github.com/en/actions/using-workflows/events-that-trigger-workflows#workflow_dispatch

