### PR TITLE
Upgrade chrome-launcher dependency

### DIFF
--- a/packages/target-chrome-app/package.json
+++ b/packages/target-chrome-app/package.json
@@ -21,7 +21,7 @@
   "main": "src/index.js",
   "dependencies": {
     "@loki/target-chrome-core": "^0.29.0",
-    "chrome-launcher": "^0.13.4",
+    "chrome-launcher": "^0.14.1",
     "chrome-remote-interface": "^0.29.0",
     "debug": "^4.1.1"
   },

--- a/yarn.lock
+++ b/yarn.lock
@@ -7405,17 +7405,15 @@ chrome-aws-lambda@^2.0.1:
   dependencies:
     lambdafs "^1.3.0"
 
-chrome-launcher@^0.13.4:
-  version "0.13.4"
-  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.13.4.tgz#4c7d81333c98282899c4e38256da23e00ed32f73"
-  integrity sha512-nnzXiDbGKjDSK6t2I+35OAPBy5Pw/39bgkb/ZAFwMhwJbdYBp6aH+vW28ZgtjdU890Q7D+3wN/tB8N66q5Gi2A==
+chrome-launcher@^0.14.1:
+  version "0.14.2"
+  resolved "https://registry.yarnpkg.com/chrome-launcher/-/chrome-launcher-0.14.2.tgz#5cb334794b9e83fad7303c96c131a4ec9e9f83a6"
+  integrity sha512-Nk8DUCIfPR6p9WClPPFeP2ztpAdkT8xueoiDS03csea1uoJjm4w0p5Oy1hjykyjT1EQ0MMrEshLD3C8gHXyiZw==
   dependencies:
     "@types/node" "*"
-    escape-string-regexp "^1.0.5"
+    escape-string-regexp "^4.0.0"
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
-    mkdirp "^0.5.3"
-    rimraf "^3.0.2"
 
 chrome-remote-interface@^0.29.0:
   version "0.29.0"


### PR DESCRIPTION
This fixes an issue where chrome would fail to launch if `localhost` resolved to the IPv6 address `::1` on Node 17.

Fixes #369.