### PR TITLE
Update chrome-remote-interface to fix connection problem with Node 18

### DIFF
--- a/packages/target-chrome-app/package.json
+++ b/packages/target-chrome-app/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@loki/target-chrome-core": "^0.30.1",
     "chrome-launcher": "^0.14.1",
-    "chrome-remote-interface": "^0.29.0",
+    "chrome-remote-interface": "^0.31.3",
     "debug": "^4.1.1"
   },
   "publishConfig": {

--- a/packages/target-chrome-docker/package.json
+++ b/packages/target-chrome-docker/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@loki/core": "^0.30.0",
     "@loki/target-chrome-core": "^0.30.1",
-    "chrome-remote-interface": "^0.29.0",
+    "chrome-remote-interface": "^0.31.3",
     "debug": "^4.1.1",
     "execa": "^5.0.0",
     "fs-extra": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7426,10 +7426,10 @@ chrome-launcher@^0.14.1:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chrome-remote-interface@^0.29.0:
-  version "0.29.0"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.29.0.tgz#4f9089f37aa2281e0e8b2d5bf03749f56f1cc85f"
-  integrity sha512-/XJCFa03p7fxZJt/Zn7eFlS6KWkghEUDRmj9hqnlUg98HYvrH+yoPMoh3IyM5M9bWs7k0noynXanhBzKrdjOoA==
+chrome-remote-interface@^0.31.3:
+  version "0.31.3"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.31.3.tgz#bd01b89f5f0e968f7eeb37b8b7c5ac20e6e1f4d0"
+  integrity sha512-NTwb1YNPHXLTus1RjqsLxJmdViKwKJg/lrFEcM6pbyQy04Ow2QKWHXyPpxzwE+dFsJghWuvSAdTy4W0trluz1g==
   dependencies:
     commander "2.11.x"
     ws "^7.2.0"


### PR DESCRIPTION
@techeverri

Closes: #405 

This PR fixes the `ECONNREFUSED` error when using `loki` with Node 17+ described in #405.

DNS lookup returns IPv6 with Node 17+, which breaks the `chrome-remote-interface` initialization. However, this problem was fixed in a newer version of the `chrome-remote-interface` package, so updating the package solved the issue for me.