### PR TITLE
Add support for targetting a specific device ID when running in React Native

### DIFF
--- a/docs/command-line-arguments.md
+++ b/docs/command-line-arguments.md
@@ -34,7 +34,7 @@ yarn loki test -- --port 9009
 | **`--chromeDockerUseCopy`**             | Use docker copy instead of volume mount for local stories                                                                                       | `false`                                                   |
 | **`--chromeEnableAnimations`**          | Enable CSS transitions and animations.                                                                                                          | `false`                                                   |
 | **`--chromeFlags`**                     | Custom chrome flags.                                                                                                                            | `--headless --disable-gpu --hide-scrollbars`              |
-| **`--chromeLoadTimeout`**               | How many miliseconds loki will wait for the page to load before taking as screnshot.                                                            | `60000`                                                   |
+| **`--chromeLoadTimeout`**               | How many milliseconds loki will wait for the page to load before taking as screenshot.                                                          | `60000`                                                   |
 | **`--chromeRetries`**                   | The number of retries for taking the screenshot, in case of failure.                                                                            | `0`                                                       |
 | **`--chromeSelector`**                  | CSS selector to the part of the DOM to screenshot. Useful you have decorators that should be excluded.                                          | `#root > *`                                               |
 | **`--chromeTolerance`**                 | How many percent tolerated difference compared to reference image. Behaviour of tolerance depends on `diffingEngine`.                           | `0`                                                       |
@@ -49,6 +49,7 @@ yarn loki test -- --port 9009
 | **`--silent`**                          | Plain text renderer that will only output errors.                                                                                               | `false`                                                   |
 | **`--dockerWithSudo`**                  | Run docker commands with sudo.                                                                                                                  | `false`                                                   |
 | **`--dockerNet`**                       | Argument to pass to docker --net, e.g. `host` or `bridge`.                                                                                      | _None_                                                    |
+| **`--device`**                          | Device/emulator ID to target for screenshots. Useful when running multiple devices on a single machine.                                         | _None_                                                    |
 
 ## `loki update`
 

--- a/packages/runner/src/commands/test/parse-options.js
+++ b/packages/runner/src/commands/test/parse-options.js
@@ -59,6 +59,7 @@ function parseOptions(args, config) {
     chromeDockerUseCopy: $('chromeDockerUseCopy'),
     chromeDockerWithoutSeccomp: $('chromeDockerWithoutSeccomp'),
     passWithNoStories: $('passWithNoStories'),
+    device: $('device'),
   };
 }
 

--- a/packages/runner/src/commands/test/run-tests.js
+++ b/packages/runner/src/commands/test/run-tests.js
@@ -267,14 +267,20 @@ async function runTests(flatConfigurations, options) {
       case 'ios.simulator': {
         return getTargetTasks(
           target,
-          createIOSSimulatorTarget(options.reactNativeUri),
+          createIOSSimulatorTarget({
+            socketUri: options.reactNativeUri,
+            device: options.device,
+          }),
           configurations
         );
       }
       case 'android.emulator': {
         return getTargetTasks(
           target,
-          createAndroidEmulatorTarget(options.reactNativeUri),
+          createAndroidEmulatorTarget({
+            socketUri: options.reactNativeUri,
+            device: options.device,
+          }),
           configurations
         );
       }

--- a/packages/target-native-android-emulator/package.json
+++ b/packages/target-native-android-emulator/package.json
@@ -20,10 +20,10 @@
   ],
   "main": "src/index.js",
   "dependencies": {
+    "@ferocia-oss/osnap": "^1.3.0",
     "@loki/core": "^0.30.0",
     "@loki/target-native-core": "^0.30.0",
     "fs-extra": "^9.1.0",
-    "osnap": "^1.1.0",
     "tempy": "^1.0.0"
   },
   "publishConfig": {

--- a/packages/target-native-android-emulator/src/create-android-emulator-target.js
+++ b/packages/target-native-android-emulator/src/create-android-emulator-target.js
@@ -3,15 +3,15 @@ const tempy = require('tempy');
 const osnap = require('osnap/src/android');
 const { createWebsocketTarget } = require('@loki/target-native-core');
 
-const captureScreenshot = async () => {
+const captureScreenshot = async (device) => {
   const filename = tempy.file({ extension: 'png' });
-  await osnap.saveToFile({ filename });
+  await osnap.saveToFile({ filename, device });
   const screenshot = await fs.readFile(filename);
   await fs.unlink(filename);
   return screenshot;
 };
 
-const createAndroidEmulatorTarget = (socketUri) =>
-  createWebsocketTarget(socketUri, 'android', captureScreenshot);
+const createAndroidEmulatorTarget = ({ socketUri, device }) =>
+  createWebsocketTarget(socketUri, 'android', () => captureScreenshot(device));
 
 module.exports = createAndroidEmulatorTarget;

--- a/packages/target-native-ios-simulator/package.json
+++ b/packages/target-native-ios-simulator/package.json
@@ -20,10 +20,10 @@
   ],
   "main": "src/index.js",
   "dependencies": {
+    "@ferocia-oss/osnap": "^1.3.0",
     "@loki/core": "^0.30.0",
     "@loki/target-native-core": "^0.30.0",
     "fs-extra": "^9.1.0",
-    "osnap": "^1.1.0",
     "tempy": "^1.0.0"
   },
   "publishConfig": {

--- a/packages/target-native-ios-simulator/src/create-ios-simulator-target.js
+++ b/packages/target-native-ios-simulator/src/create-ios-simulator-target.js
@@ -4,9 +4,9 @@ const osnap = require('osnap/src/ios');
 const { withRetries } = require('@loki/core');
 const { createWebsocketTarget } = require('@loki/target-native-core');
 
-const captureScreenshot = withRetries(3)(async () => {
+const captureScreenshot = withRetries(3)(async (device) => {
   const filename = tempy.file({ extension: 'png' });
-  await osnap.saveToFile({ filename });
+  await osnap.saveToFile({ filename, device });
   const { size } = await fs.stat(filename);
   if (size === 0) {
     throw new Error('Screenshot failed ');
@@ -16,7 +16,7 @@ const captureScreenshot = withRetries(3)(async () => {
   return screenshot;
 });
 
-const createIOSSimulatorTarget = (socketUri) =>
-  createWebsocketTarget(socketUri, 'ios', captureScreenshot);
+const createIOSSimulatorTarget = ({ socketUri, device }) =>
+  createWebsocketTarget(socketUri, 'ios', () => captureScreenshot(device));
 
 module.exports = createIOSSimulatorTarget;


### PR DESCRIPTION
Currently when running loki on a machine with multiple iOS simulators, loki will use the first booted device to use for screenshots.

In our CI we run 3 side-by-side iOS simulators on each machine which results in screenshots being captured from the incorrect simulator.

This PR adds a new `--device` flag to loki which allows you to specify the device ID to use for screenshots. We've [forked osnap](https://github.com/ferocia/osnap) which is no longer maintained and [added support for selecting a device ID for iOS](https://github.com/ferocia/osnap/pull/1). It already had support for Android.

I know there was some dicussion about proper concurrency support in #71, but given the age of that issue I assume there hasn't been any progress in that space.