### PR TITLE
Update chrome-remote-interface to resolve DevTools connection issue

### DIFF
--- a/packages/target-chrome-app/package.json
+++ b/packages/target-chrome-app/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@loki/target-chrome-core": "^0.31.0",
     "chrome-launcher": "^0.14.1",
-    "chrome-remote-interface": "^0.31.3",
+    "chrome-remote-interface": "^0.32.1",
     "debug": "^4.1.1"
   },
   "publishConfig": {

--- a/packages/target-chrome-docker/package.json
+++ b/packages/target-chrome-docker/package.json
@@ -22,7 +22,7 @@
   "dependencies": {
     "@loki/core": "^0.31.0",
     "@loki/target-chrome-core": "^0.31.0",
-    "chrome-remote-interface": "^0.31.3",
+    "chrome-remote-interface": "^0.32.1",
     "debug": "^4.1.1",
     "execa": "^5.0.0",
     "fs-extra": "^9.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -7426,10 +7426,10 @@ chrome-launcher@^0.14.1:
     is-wsl "^2.2.0"
     lighthouse-logger "^1.0.0"
 
-chrome-remote-interface@^0.31.3:
-  version "0.31.3"
-  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.31.3.tgz#bd01b89f5f0e968f7eeb37b8b7c5ac20e6e1f4d0"
-  integrity sha512-NTwb1YNPHXLTus1RjqsLxJmdViKwKJg/lrFEcM6pbyQy04Ow2QKWHXyPpxzwE+dFsJghWuvSAdTy4W0trluz1g==
+chrome-remote-interface@^0.32.1:
+  version "0.32.1"
+  resolved "https://registry.yarnpkg.com/chrome-remote-interface/-/chrome-remote-interface-0.32.1.tgz#e3478ca712223e51c4df7294cbc536f868ca0aa6"
+  integrity sha512-CU3/K/8YlU2H0DjsLRbxPsG4piiSGUcIy6GkGXF11SqOYoIeuUBivOsGXScaZnTyC1p4wFSR+GNmAM434/ALWw==
   dependencies:
     commander "2.11.x"
     ws "^7.2.0"


### PR DESCRIPTION
Update `chrome-remote-interface` to version 0.32.1 to resolve https://github.com/oblador/loki/issues/442