### PR TITLE
Add storybook 7 support

### DIFF
--- a/packages/browser/src/get-stories.js
+++ b/packages/browser/src/get-stories.js
@@ -1,6 +1,6 @@
 /* eslint-disable no-underscore-dangle */
 
-const getStories = (window) => {
+const getStories = async (window) => {
   const getStorybook =
     (window.__STORYBOOK_CLIENT_API__ && window.__STORYBOOK_CLIENT_API__.raw) ||
     (window.loki && window.loki.getStorybook);
@@ -18,6 +18,13 @@ const getStories = (window) => {
     'framework',
     'storySource',
   ];
+
+  if (
+    window.__STORYBOOK_CLIENT_API__.storyStore &&
+    window.__STORYBOOK_CLIENT_API__.storyStore.cacheAllCSFFiles
+  ) {
+    await window.__STORYBOOK_CLIENT_API__.storyStore.cacheAllCSFFiles();
+  }
 
   const isSerializable = (value) => {
     try {

--- a/packages/runner/src/commands/test/default-options.json
+++ b/packages/runner/src/commands/test/default-options.json
@@ -8,7 +8,7 @@
   "chromeFlags": "--headless --disable-gpu --hide-scrollbars",
   "chromeLoadTimeout": "60000",
   "chromeRetries": "0",
-  "chromeSelector": "#root > *",
+  "chromeSelector": "#root > *, #storybook-root > *",
   "chromeTolerance": "0",
   "host": "localhost",
   "output": "./.loki/current",


### PR DESCRIPTION
This adds support for the new format of stories in storybook 7.

It fixes #436 with a solution proposed by @AleksRap.

As far as I see this should also be backwards compatible with older storybook versions.