### PR TITLE
Add link to React example in docs/configuration.md

### DIFF
--- a/docs/configuration.md
+++ b/docs/configuration.md
@@ -38,7 +38,7 @@ Example `package.json`:
 }
 ```
 
-You may also use a file named `.lokirc`, `.lokirc.json` or `loki.config.js` (see the react example) if you don't want to pollute your `package.json`.
+You may also use a file named `.lokirc`, `.lokirc.json` or `loki.config.js` ([see the react example](https://github.com/oblador/loki/tree/master/examples/react)) if you don't want to pollute your `package.json`.
 
 ## `chromeSelector`
 


### PR DESCRIPTION
At the moment, the link to react example is missing in the docs. I added this link https://github.com/oblador/loki/tree/master/examples/react to the configuration file

![CleanShot 2023-06-22 at 9 32 30](https://github.com/oblador/loki/assets/17102399/6e980b99-b632-4561-be46-a3070c3905ae)
