### PR TITLE
Lock Chrome version in docker tests

### DIFF
--- a/packages/target-chrome-docker/src/create-chrome-docker-target.js
+++ b/packages/target-chrome-docker/src/create-chrome-docker-target.js
@@ -43,7 +43,7 @@ const waitOnCDPAvailable = (host, port) =>
 
 function createChromeDockerTarget({
   baseUrl = 'http://localhost:6006',
-  chromeDockerImage = 'yukinying/chrome-headless-browser-stable',
+  chromeDockerImage = 'yukinying/chrome-headless-browser-stable:100.0.4896.127',
   chromeFlags = ['--headless', '--disable-gpu', '--hide-scrollbars'],
   dockerNet = null,
   dockerWithSudo = false,
@@ -180,7 +180,13 @@ function createChromeDockerTarget({
   async function stop() {
     if (dockerId) {
       debug(`Killing chrome docker instance with id ${dockerId}`);
-      await execute(dockerPath, ['kill', dockerId]);
+      try {
+        await execute(dockerPath, ['kill', dockerId]);
+      } catch (e) {
+        if (e.toString().indexOf('No such container') === -1) {
+          throw e;
+        }
+      }
     } else {
       debug('No chrome docker instance to kill');
     }


### PR DESCRIPTION
Previously the unit tests used `latest` which caused them to suddenly fail because Chrome is crashing. Long term we would probably want to investigate why latest version is crashing (if it's an issue with the docker image or with the GitHub Action environment). 