### PR TITLE
Add missing core dependency to target-chrome-app

### DIFF
--- a/packages/target-chrome-app/package.json
+++ b/packages/target-chrome-app/package.json
@@ -20,6 +20,7 @@
   ],
   "main": "src/index.js",
   "dependencies": {
+    "@loki/core": "^0.33.0",
     "@loki/target-chrome-core": "^0.33.0",
     "chrome-launcher": "^0.14.1",
     "chrome-remote-interface": "^0.32.1",


### PR DESCRIPTION
Fixes #488 