### PR TITLE
Update @storybook/react peer dependency in @loki/integration-react

### DIFF
--- a/packages/integration-react/package.json
+++ b/packages/integration-react/package.json
@@ -23,7 +23,7 @@
     "@loki/browser": "^0.33.0"
   },
   "peerDependencies": {
-    "@storybook/react": "^5 || ^6"
+    "@storybook/react": "^5 || ^6 || ^7"
   },
   "peerDependenciesMeta": {
     "@storybook/react": {


### PR DESCRIPTION
This should solve issue with the following warnings observed when installing `loki`:
```
npm install --save-dev loki

npm WARN ERESOLVE overriding peer dependency
npm WARN While resolving: @loki/integration-react@0.33.0
npm WARN Found: @storybook/react@7.5.2
npm WARN node_modules/@storybook/react
npm WARN   dev @storybook/react@"^7.5.2" from the root project
npm WARN   3 more (@storybook/preset-react-webpack, ...)
npm WARN 
npm WARN Could not resolve dependency:
npm WARN peerOptional @storybook/react@"^5 || ^6" from @loki/integration-react@0.33.0
npm WARN node_modules/loki/node_modules/@loki/integration-react
npm WARN   @loki/integration-react@"^0.33.0" from loki@0.33.0
npm WARN   node_modules/loki
npm WARN 
npm WARN Conflicting peer dependency: @storybook/react@6.5.16
npm WARN node_modules/@storybook/react
npm WARN   peerOptional @storybook/react@"^5 || ^6" from @loki/integration-react@0.33.0
npm WARN   node_modules/loki/node_modules/@loki/integration-react
npm WARN     @loki/integration-react@"^0.33.0" from loki@0.33.0
npm WARN     node_modules/loki
```

I'm using npm v10.1.0.