### PR TITLE
fix: make is-loki-running include types in the package

### DIFF
--- a/packages/is-loki-running/package.json
+++ b/packages/is-loki-running/package.json
@@ -17,7 +17,7 @@
   "license": "MIT",
   "files": [
     "src",
-    "*.d.ts",
+    "*.d.ts"
   ],
   "main": "src/index.web.js",
   "react-native": "src/index.native.js",


### PR DESCRIPTION
This PR fixes the issue where the type definitions are missing when installing the package from npm.