### PR TITLE
Fix - Make loki work with Storybook8

### DIFF
--- a/packages/browser/src/get-stories.js
+++ b/packages/browser/src/get-stories.js
@@ -3,6 +3,7 @@
 const getStories = async (window) => {
   const getStorybook =
     (window.__STORYBOOK_CLIENT_API__ && window.__STORYBOOK_CLIENT_API__.raw) ||
+    (window.__STORYBOOK_PREVIEW__ && window.__STORYBOOK_PREVIEW__.extract && window.__STORYBOOK_PREVIEW__.storyStore.raw) ||
     (window.loki && window.loki.getStorybook);
   if (!getStorybook) {
     throw new Error(
@@ -19,13 +20,6 @@ const getStories = async (window) => {
     'storySource',
   ];
 
-  if (
-    window.__STORYBOOK_CLIENT_API__.storyStore &&
-    window.__STORYBOOK_CLIENT_API__.storyStore.cacheAllCSFFiles
-  ) {
-    await window.__STORYBOOK_CLIENT_API__.storyStore.cacheAllCSFFiles();
-  }
-
   const isSerializable = (value) => {
     try {
       JSON.stringify(value);
@@ -34,6 +28,37 @@ const getStories = async (window) => {
       return false;
     }
   };
+
+  if (window.__STORYBOOK_PREVIEW__ && window.__STORYBOOK_PREVIEW__.extract) {
+    // New official API to extract stories from preview
+    await window.__STORYBOOK_PREVIEW__.extract();
+
+    // Deprecated, will be removed in V9
+    const stories = window.__STORYBOOK_PREVIEW__.storyStore.raw();
+
+    return stories
+      .map((component) => ({
+        id: component.id,
+        kind: component.kind,
+        story: component.story,
+        parameters: Object.fromEntries(
+          Object.entries(component.parameters || {}).filter(
+            ([key, value]) =>
+              !key.startsWith('__') &&
+              !blockedParams.includes(key) &&
+              isSerializable(value)
+          )
+        ),
+      }))
+      .filter(({ parameters }) => !parameters.loki || !parameters.loki.skip);
+  }
+
+  if (
+    window.__STORYBOOK_CLIENT_API__.storyStore &&
+    window.__STORYBOOK_CLIENT_API__.storyStore.cacheAllCSFFiles
+  ) {
+    await window.__STORYBOOK_CLIENT_API__.storyStore.cacheAllCSFFiles();
+  }
 
   return getStorybook()
     .map((component) => ({

--- a/packages/browser/src/get-stories.js
+++ b/packages/browser/src/get-stories.js
@@ -3,7 +3,9 @@
 const getStories = async (window) => {
   const getStorybook =
     (window.__STORYBOOK_CLIENT_API__ && window.__STORYBOOK_CLIENT_API__.raw) ||
-    (window.__STORYBOOK_PREVIEW__ && window.__STORYBOOK_PREVIEW__.extract && window.__STORYBOOK_PREVIEW__.storyStore.raw) ||
+    (window.__STORYBOOK_PREVIEW__ &&
+      window.__STORYBOOK_PREVIEW__.extract &&
+      window.__STORYBOOK_PREVIEW__.storyStore.raw) ||
     (window.loki && window.loki.getStorybook);
   if (!getStorybook) {
     throw new Error(


### PR DESCRIPTION
This PR enables loki on Storybook 8. 

It only fixes the API calls required but doesn't challenge the core concepts which rely on `storyStore.raw()`. That is still deprecated and will be gone for Storybook 9.

fixes #503 