### PR TITLE
Fix: ensure types are included for create-async-callback package

### DIFF
--- a/packages/create-async-callback/package.json
+++ b/packages/create-async-callback/package.json
@@ -16,7 +16,8 @@
   },
   "license": "MIT",
   "files": [
-    "src"
+    "src",
+    "*.d.ts"
   ],
   "main": "src/index.web.js",
   "react-native": "src/index.native.js",


### PR DESCRIPTION
## Summary

When installing `@loki/create-async-callback` from npm its [types](https://github.com/oblador/loki/blob/master/packages/create-async-callback/index.d.ts) are not included in the package.

Similar to this [previous PR](https://github.com/oblador/loki/pull/500) for `@loki/is-loki-running` this PR ensures the types are included in the package by adding  `*.d.ts` to the `files` in the `package.json`.