### PR TITLE
bump react, react-dom and ink versions to latest

### DIFF
--- a/examples/react-native/package.json
+++ b/examples/react-native/package.json
@@ -11,7 +11,7 @@
     "update-loki": "LOKI_FILE=`cd ../.. && echo \\`pwd\\`/\\`npm pack\\`` && npm install $LOKI_FILE --no-save && rm $LOKI_FILE"
   },
   "dependencies": {
-    "react": "17.0.2",
+    "react": "18.3.1",
     "react-native": "0.68.2"
   },
   "devDependencies": {

--- a/examples/react/package.json
+++ b/examples/react/package.json
@@ -6,8 +6,8 @@
     "@testing-library/jest-dom": "^5.14.1",
     "@testing-library/react": "^12.0.0",
     "@testing-library/user-event": "^13.2.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "react": "^18.3.1",
+    "react-dom": "^18.3.1",
     "react-motion": "^0.5.2",
     "react-scripts": "5.0.0",
     "web-vitals": "^2.1.0"

--- a/packages/runner/package.json
+++ b/packages/runner/package.json
@@ -41,10 +41,10 @@
     "cosmiconfig": "^7.0.0",
     "fs-extra": "^9.1.0",
     "import-jsx": "^4.0.1",
-    "ink": "^3.2.0",
+    "ink": "^5.0.1",
     "minimist": "^1.2.0",
     "ramda": "^0.27.1",
-    "react": "^17.0.2",
+    "react": "^18.3.1",
     "transliteration": "^2.2.0"
   }
 }


### PR DESCRIPTION
**Description**
This pull request updates the dependencies for react, react-dom, and ink to their latest versions.

**Motivation**
The update is necessary to resolve peer dependency issues encountered when using pnpm with React version 18.3.1. This ensures compatibility and smooth installation for projects utilizing the latest React version.

**Context**
pnpm enforces strict peer dependency resolution. If a project uses React 18 but one of its dependencies requires React 17, pnpm will flag this as a conflict, potentially preventing successful installation. By aligning the library's dependencies with the latest React version, this PR mitigates such issues.

The ink package needs to be updated as well, as it relies on an older version of react-reconcile, which is also problematic for dependency resolution with the latest React version.