### PR TITLE
fix(loki.config): prevent test failure from known failing URLs in examples

### DIFF
--- a/examples/react/loki.config.js
+++ b/examples/react/loki.config.js
@@ -7,14 +7,6 @@ module.exports = {
       width: 1366,
       height: 768,
     },
-    'chrome.iphone7': {
-      target: 'chrome.docker',
-      preset: 'iPhone 7',
-    },
-    'chrome.a4': {
-      target: 'chrome.docker',
-      preset: 'A4 Paper',
-    },
   },
-  fetchFailIgnore: 'localhost:1234/get',
+  fetchFailIgnore: 'localhost:1234/get|192\\.168\\.29\\.108:6006/runtime-error',
 };

--- a/examples/react/loki.config.js
+++ b/examples/react/loki.config.js
@@ -7,6 +7,14 @@ module.exports = {
       width: 1366,
       height: 768,
     },
+    'chrome.iphone7': {
+      target: 'chrome.docker',
+      preset: 'iPhone 7',
+    },
+    'chrome.a4': {
+      target: 'chrome.docker',
+      preset: 'A4 Paper',
+    },
   },
   fetchFailIgnore: 'localhost:1234/get|192\\.168\\.29\\.108:6006/runtime-error',
 };


### PR DESCRIPTION
closes #499 
his PR adds a fetchFailIgnore config in examples/react/loki.config.js to avoid test failures caused by expected fetch failures from:

    http://localhost:1234/get

    http://192.168.29.108:6006/runtime-error

These are used in specific stories to simulate fetch failures or runtime issues, but currently cause the visual tests to fail by defaut

### current output 

```

Connected!
 PASS  chrome.docker/chrome.laptop/isLokiRunning()
 PASS  chrome.docker/chrome.laptop/Fetch Components
 PASS  chrome.docker/chrome.laptop/Decorators
 PASS  chrome.docker/chrome.laptop/Media
 PASS  chrome.docker/chrome.laptop/CSF
 PASS  chrome.docker/chrome.laptop/Animation
 PASS  chrome.docker/chrome.laptop/Text
 PASS  chrome.docker/chrome.laptop/FocusedInput
 PASS  chrome.docker/chrome.laptop/Asynchronous render
 PASS  chrome.docker/chrome.laptop/Hover
 PASS  chrome.docker/chrome.laptop/Long Element
 PASS  chrome.docker/chrome.laptop/Positions
 PASS  chrome.docker/chrome.laptop/Multiple elements
 PASS  chrome.docker/chrome.laptop/Zero height
 PASS  chrome.docker/chrome.iphone7/isLokiRunning()
 PASS  chrome.docker/chrome.iphone7/Fetch Components
 PASS  chrome.docker/chrome.iphone7/Decorators
 PASS  chrome.docker/chrome.iphone7/Media
 PASS  chrome.docker/chrome.iphone7/CSF
 PASS  chrome.docker/chrome.iphone7/Animation
 PASS  chrome.docker/chrome.iphone7/Text
 PASS  chrome.docker/chrome.iphone7/FocusedInput
 PASS  chrome.docker/chrome.iphone7/Asynchronous render
 PASS  chrome.docker/chrome.iphone7/Hover
 PASS  chrome.docker/chrome.iphone7/Long Element
 PASS  chrome.docker/chrome.iphone7/Positions
 PASS  chrome.docker/chrome.iphone7/Multiple elements
 PASS  chrome.docker/chrome.iphone7/Zero height
 PASS  chrome.docker/chrome.a4/isLokiRunning()
 PASS  chrome.docker/chrome.a4/Fetch Components
 PASS  chrome.docker/chrome.a4/Decorators
 PASS  chrome.docker/chrome.a4/Media
 PASS  chrome.docker/chrome.a4/CSF
 PASS  chrome.docker/chrome.a4/Animation
 PASS  chrome.docker/chrome.a4/Text
 PASS  chrome.docker/chrome.a4/FocusedInput
 PASS  chrome.docker/chrome.a4/Hover
 PASS  chrome.docker/chrome.a4/Asynchronous render
 PASS  chrome.docker/chrome.a4/Long Element
 PASS  chrome.docker/chrome.a4/Positions
 PASS  chrome.docker/chrome.a4/Multiple elements
 PASS  chrome.docker/chrome.a4/Zero height
 PASS  chrome.docker
Done in 30.68s.
```
